### PR TITLE
Fix "Read more" links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,6 +72,7 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: baseUrl,
+  trailingSlash: false,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
https://agileworld.siemens.cloud/jira/browse/IX-2657

## 💡 What is the current behavior?

When manually entering a URL in the browser a trailing slash is added, breaking relative URLs in the documentation.

## 🆕 What is the new behavior?

No trailing slash is added anymore, by setting trailingSlash: false in the docusaurus config.
