### PR TITLE
Fix/2676 code preview color

### DIFF
--- a/docs/home/theming/usage-developers.md
+++ b/docs/home/theming/usage-developers.md
@@ -21,6 +21,19 @@ Siemens AG employees can access the Corporate Brand Theme at [**https://code.sie
 
 ## How to set a theme
 
+To choose a theme set the `data-ix-theme` attribute of the `<body>` tag to the theme of choice (e.g. `classic`).
+The default is `classic` in `dark` mode. To enable light mode, set the `data-ix-color-schema` attribute to `light` instead.
+
+```html
+<html>
+  <!-- Framework related imports -->
+  <!--  -->
+  <body data-ix-theme="classic" data-ix-schema="dark"></body>
+</html>
+```
+
+The CSS class based theme configuration is still supported, but will be removed in version 4.0.0:
+
 The default theme is `theme-classic-dark`. To set a different theme, change the `class` attribute of the `<body>` tag to contain e.g. `theme-classic-light` instead of `theme-classic-dark`.
 
 ```html

--- a/docs/home/theming/usage-developers.md
+++ b/docs/home/theming/usage-developers.md
@@ -28,7 +28,7 @@ The default is `classic` in `dark` mode. To enable light mode, set the `data-ix-
 <html>
   <!-- Framework related imports -->
   <!--  -->
-  <body data-ix-theme="classic" data-ix-schema="dark"></body>
+  <body data-ix-theme="classic" data-ix-color-schema="dark"></body>
 </html>
 ```
 

--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -91,6 +91,7 @@ export default function CodePreview(props: Readonly<CodePreviewProps>) {
                 return (
                   <IxDropdownItem
                     key={name}
+                    className={styles.DropdownItem}
                     checked={selectedFile === name}
                     onClick={() => {
                       setSelectedFile(name);

--- a/src/components/CodePreview/styles.module.css
+++ b/src/components/CodePreview/styles.module.css
@@ -15,6 +15,10 @@
   margin-right: auto;
 }
 
+.DropdownItem {
+  color: var(--theme-color-std-text);
+}
+
 .sourceFileName {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

Code preview dropdown items show wrong color if documentation theme mode is different from code preview.
 
GitHub Issue Number: IX-2676

## 🆕 What is the new behavior?

Correct color is used.
-
-

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
