### PR TITLE
Docs/about legal

### DIFF
--- a/docs/components/about-and-legal/guide.md
+++ b/docs/components/about-and-legal/guide.md
@@ -17,8 +17,8 @@ The About and legal component appears when users click on the "About and legal" 
 ## Options
 
 - **Tabs:** Use tabs with meaningful labels to separate content into categories.
-- **Label:** Title that is shown in the content header. We recommend to use the default "About & legal information".
-- **Content:** Add information about the application e.g. version, author, copyright. It can also include legal information e.g. terms of service, privacy policy.
+- **Label:** Title that is shown in the content header. We recommend using the default "About & legal information" wording.
+- **Content:** Add information about the application, e.g. version, author, copyright. It can also include legal information, e.g. terms of service, privacy policy.
 
 ## Behavior
 

--- a/docs/components/about-and-legal/guide.md
+++ b/docs/components/about-and-legal/guide.md
@@ -4,15 +4,21 @@ doc-type: 'tab-item'
 
 # About and legal - Usage
 
-The About and legal component appears when users click on the "About and legal" icon (1) and overlays the current content. Closing this overlay brings users back to the original content.
+The About and legal component appears when users click on the "About and legal" item (1) and overlays the current content. Closing this overlay brings users back to the original content.
 
 ![About and legal overlay](https://www.figma.com/design/wEptRgAezDU1z80Cn3eZ0o/iX-Pattern-Illustrations?type=design&node-id=1029-79866&mode=design&t=Ntzn8IlSOlPey8s5-11)
 
-- (1) Info icon: opens and closes the About and legal overlay
-- (2) Replaceable content header: with default string "About & legal information"
-- (3) Close button: closes the overlay
-- (4) Tabs (optional): navigates through multiple content categories
-- (5) Changeable content: we use this to add specific application information and local legal regulations (note our Figma design is our personal recommendation)
+1. Application menu item - info
+2. Content header
+3. Close button
+4. Tabs
+5. Changeable content
+
+## Options
+
+- **Tabs:** Use tabs with meaningful labels to separate content into categories.
+- **Label of about menu:** Title that is shown in the content header. We recommend to use the default "About & legal information".
+- **Content:** Add information about the application e.g. version, author, copyright. It can also include legal information e.g. terms of service, privacy policy.
 
 ## Behavior
 
@@ -25,3 +31,7 @@ The overlay can be closed in three ways:
 - Click another navigation item.
 
 When the navigation menu is collapsed, the overlay stays open.
+
+:::info
+The About and Legal components require specific content to comply with Siemens AG regulations. The official content and guidelines are exclusively available for Siemens AG employees and can be accessed at [CHANGE ME](TBD).
+:::

--- a/docs/components/about-and-legal/guide.md
+++ b/docs/components/about-and-legal/guide.md
@@ -17,7 +17,7 @@ The About and legal component appears when users click on the "About and legal" 
 ## Options
 
 - **Tabs:** Use tabs with meaningful labels to separate content into categories.
-- **Label of about menu:** Title that is shown in the content header. We recommend to use the default "About & legal information".
+- **Label:** Title that is shown in the content header. We recommend to use the default "About & legal information".
 - **Content:** Add information about the application e.g. version, author, copyright. It can also include legal information e.g. terms of service, privacy policy.
 
 ## Behavior
@@ -33,5 +33,5 @@ The overlay can be closed in three ways:
 When the navigation menu is collapsed, the overlay stays open.
 
 :::info
-The About and Legal components require specific content to comply with Siemens AG regulations. The official content and guidelines are exclusively available for Siemens AG employees and can be accessed [here](https://code.siemens.com/siemens-ix/ix-brand-theme/apps/documentation/src/pages/about-legal-information.md).
+The About and Legal components require specific content to comply with Siemens AG regulations. The official content and guidelines are exclusively available for Siemens AG employees and can be accessed [here](https://code.siemens.com/siemens-ix/ix-brand-theme/-/blob/af74de1ec3c7d9b1fdd6e06e9c0c6eadefaf695b/apps/documentation/src/pages/about-legal-information.md).
 :::

--- a/docs/components/about-and-legal/guide.md
+++ b/docs/components/about-and-legal/guide.md
@@ -33,5 +33,5 @@ The overlay can be closed in three ways:
 When the navigation menu is collapsed, the overlay stays open.
 
 :::info
-The About and Legal components require specific content to comply with Siemens AG regulations. The official content and guidelines are exclusively available for Siemens AG employees and can be accessed at [CHANGE ME](TBD).
+The About and Legal components require specific content to comply with Siemens AG regulations. The official content and guidelines are exclusively available for Siemens AG employees and can be accessed [here](https://code.siemens.com/siemens-ix/ix-brand-theme/apps/documentation/src/pages/about-legal-information.md).
 :::

--- a/docs/home/support/faq.md
+++ b/docs/home/support/faq.md
@@ -91,6 +91,11 @@ Our codebase is openly and freely accessible for anyone to view, modify and dist
 We are working towards meeting the WCAG (Web Content Accessibility Guidelines) and other relevant accessibility standards. Our team is dedicated to ensuring that our design system is accessible to all users. While we’re still in the process of fully aligning with these guidelines, we have made significant progress and are continuously improving our accessibility features. We appreciate your patience and understanding as we strive to achieve full compliance. For specific accessibility concerns or updates on our progress, please feel free to reach out to our team.
 </Accordion>
 
-<Accordion title="How does the release schedule work?" id="release-info" showBorderBottom>
+<Accordion title="How does the release schedule work?" id="release-info">
 The Siemens Industrial Experience design team provides a transparent versioning and release process. For more details on our versioning, release types, frequency, and support policies, visit our [Roadmap](https://ix.siemens.io/docs/roadmap) and [Versioning and release](https://ix.siemens.io/docs/release-info).
 </Accordion>
+
+<Accordion title="Can I use the design system to build my documentation?" id="docu-theme" showBorderBottom>
+The Siemens Industrial Experience design system is intended for building industrial applications. If you are a Siemens AG employee looking to create a documentation website, use the [official MkDocs theme](https://code.siemens.com/code-ops/docs-theme) for documentation purposes. This ensures consistency and alignment with Siemens documentation standards.
+</Accordion>
+


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

There is an about&legal definition for Siemens AG which cannot be found through our website. Additionally, the same applies for a documentation website theme.

IX-2872

## 🆕 What is the new behavior?

- For about&legal: Add block containing the link to the markdown file in the internal Brand Theme repository.
- For docu theme: Add FAQ containing the link to the internal mkdocs repository.

## Reviews

- [x] UX Review
- [x] Final edit