### PR TITLE
Docs/add figma info

### DIFF
--- a/docs/home/getting-started/designers.md
+++ b/docs/home/getting-started/designers.md
@@ -24,7 +24,7 @@ Use the horizontal navigation in the header to quickly access the desired topic.
 
 Our **Figma library** contains all designed components, styles, and blueprints ready for app design.
 
-- The **Figma library** is maintained within the Siemens AG Global account.
+- The **Figma library** is maintained within the Siemens AG Global account. As a Siemens employee with a Figma account, please search for "iX Design System" in Figma to get access to the library.
 - Siemens employees can use the self-service to obtain a Figma license. For guest access please contact us.
 - The **Figma library** contains Siemens specific brand elements and is only accessible to Siemens employees and business partners. [Get more information here](https://siemens-ix.code.siemens.io/ix-brand-theme/)
 - For the classic theme **Figma library** (open source) please [contact us](./../support/contact-us.md).

--- a/docs/home/getting-started/designers.md
+++ b/docs/home/getting-started/designers.md
@@ -24,7 +24,7 @@ Use the horizontal navigation in the header to quickly access the desired topic.
 
 Our **Figma library** contains all designed components, styles, and blueprints ready for app design.
 
-- The **Figma library** is maintained within the Siemens AG Global account. As a Siemens employee with a Figma account, please search for "iX Design System" in Figma to get access to the library.
+- The **Figma library** is maintained within the Siemens AG Global account. As a Siemens employee with a Figma license, please search for "iX Design System" in Figma to access the library.
 - Siemens employees can use the self-service to obtain a Figma license. For guest access please contact us.
 - The **Figma library** contains Siemens specific brand elements and is only accessible to Siemens employees and business partners. [Get more information here](https://siemens-ix.code.siemens.io/ix-brand-theme/)
 - For the classic theme **Figma library** (open source) please [contact us](./../support/contact-us.md).


### PR DESCRIPTION
Add info about how to find iX library in Figma for Siemens employees

<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

- Siemens employees without developer account cannot access the additional information behind the internal link.

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- added further info how to find iX library in the Siemens’ Figma account


