### PR TITLE
Add Gemini config and documentation style guide

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,2 +1,0 @@
-#Contains various configurable features that you can enable or disable, including specifying files to ignore using glob patterns
-#Find more information here: https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github?hl=de#add_configuration_files


### PR DESCRIPTION
Introduced .gemini/config.yaml for customizable Gemini Code Assist features and .gemini/styleguide.md outlining documentation and style guidelines for the project.

