### PR TITLE
fix(stackblitz):update stackblitz of documentation to use latest version 4.0.0

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -103,7 +103,7 @@ const config: Config = {
 
   customFields: {
     withBrandTheme,
-    playgroundVersion: '^3.0.0'
+    playgroundVersion: '^4.0.0'
   },
 
   presets: [

--- a/src/lib/stackblitz.ts
+++ b/src/lib/stackblitz.ts
@@ -42,11 +42,13 @@ function replaceLibraryImports(
   project: Record<string, string>,
   version: string
 ) {
-  const packageJson = project['package.json'];
-  project['package.json'] = packageJson.replace(
-    /\"<VERSION>\"/g,
-    `"${version}"`
+  let packageJson = project["package.json"];
+  packageJson = packageJson.replace(
+    /"@siemens\/ix-echarts":\s*"<VERSION>"/g,
+    '"@siemens/ix-echarts": "^3.0.0"'
   );
+  packageJson = packageJson.replace(/\"<VERSION>\"/g, `"${version}"`);
+  project["package.json"] = packageJson;
 }
 
 async function openVueStackBlitz(


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

Stackblitz in the documentation still uses old version 3.0.0

Jira ticket: [IX-3705]

## 🆕 What is the new behavior?

- Stackblitz will use the latest version of ix 4.0.0
- ix-echarts will still use the current version of 3.0.0

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
