### PR TITLE
feat: add pure storybook deployment flag

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,4 +2,6 @@ DOCS_BRANCH='main'
 DOCS_BRANCH_TYPE='branch' # Check if the branch is a pull request
 DOCS_PR_NUMBER=''
 
+DOCS_DEPLOYMENT_TYPE="storybook"
+
 BRAND_VERSION=1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate-env:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fail if storybook deployment type is configured
+        run: |
+          if grep -R --include='.env*' -nE '^[[:space:]]*DOCS_DEPLOYMENT_TYPE[[:space:]]*=[[:space:]]*"storybook"[[:space:]]*$' .; then
+            echo "DOCS_DEPLOYMENT_TYPE=storybook must not be committed in .env files for this pipeline." >&2
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   validate-env:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,6 +22,7 @@ jobs:
           fi
 
   build:
+    needs: validate-env
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy-gh-pages-version.yml
+++ b/.github/workflows/deploy-gh-pages-version.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Fail fast if storybook deployment type is configured
+        run: |
+          if grep -R --include='.env*' -nE '^[[:space:]]*DOCS_DEPLOYMENT_TYPE[[:space:]]*=[[:space:]]*"storybook"[[:space:]]*$' .; then
+            echo "DOCS_DEPLOYMENT_TYPE=storybook is not allowed for deploy pipeline." >&2
+            exit 1
+          fi
+
       - uses: ./.github/workflows/actions/turbo
 
       - name: Remove Pull Request Env

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Fail fast if storybook deployment type is configured
+        run: |
+          if grep -R --include='.env*' -nE '^[[:space:]]*DOCS_DEPLOYMENT_TYPE[[:space:]]*=[[:space:]]*"storybook"[[:space:]]*$' .; then
+            echo "DOCS_DEPLOYMENT_TYPE=storybook is not allowed for deploy pipeline." >&2
+            exit 1
+          fi
+
       - uses: ./.github/workflows/actions/turbo
 
       - name: Remove Pull Request Env

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-env:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fail if storybook deployment type is configured
+        run: |
+          if grep -R --include='.env*' -nE '^[[:space:]]*DOCS_DEPLOYMENT_TYPE[[:space:]]*=[[:space:]]*"storybook"[[:space:]]*$' .; then
+            echo "DOCS_DEPLOYMENT_TYPE=storybook must not be committed in .env files for this pipeline." >&2
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   validate-env:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,6 +26,7 @@ jobs:
           fi
 
   build:
+    needs: validate-env
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,20 @@ jobs:
 
       - name: Fail if storybook deployment type is configured
         run: |
-          if grep -R --include='.env*' -nE '^[[:space:]]*DOCS_DEPLOYMENT_TYPE[[:space:]]*=[[:space:]]*"storybook"[[:space:]]*$' .; then
-            echo "DOCS_DEPLOYMENT_TYPE=storybook must not be committed in .env files for this pipeline." >&2
+          matches="$(grep -R --include='.env*' -nE '^[[:space:]]*DOCS_DEPLOYMENT_TYPE[[:space:]]*=[[:space:]]*"storybook"[[:space:]]*$' . || true)"
+
+          if [ -n "$matches" ]; then
+            while IFS=: read -r file line _; do
+              echo "::error file=$file,line=$line,title=Invalid DOCS_DEPLOYMENT_TYPE::Remove DOCS_DEPLOYMENT_TYPE=\"storybook\" from committed .env files for this pipeline."
+            done <<< "$matches"
+
+            {
+              echo "### Invalid environment configuration"
+              echo ""
+              echo "Found committed .env entries setting DOCS_DEPLOYMENT_TYPE=\"storybook\"."
+              echo "Remove those entries before merging this pull request."
+            } >> "$GITHUB_STEP_SUMMARY"
+
             exit 1
           fi
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,6 +8,16 @@ import versionDeployment from './version-deployment.json' with { type: 'json ' }
 import llmstxtPostbuildPlugin from './plugins/llmstxt-postbuild/plugin';
 
 dotenv();
+dotenv({
+  path: path.join(__dirname, '.env.production'),
+});
+
+const deploymentType = process.env.DOCS_DEPLOYMENT_TYPE || 'docs';
+
+if (deploymentType === 'storybook') {
+  console.log('Using Storybook deployment configuration');
+  process.exit(0);
+}
 
 function getAnnouncementBarConfig() {
   const latestVersion = versionDeployment.versions.find(

--- a/scripts/copy-theme.ts
+++ b/scripts/copy-theme.ts
@@ -21,6 +21,8 @@ dotenv({
 
 const __dirname = path.resolve();
 const __node_modules = path.join(__dirname, 'node_modules');
+const __build = path.join(__dirname, 'build');
+const __storybookStatic = path.join(__dirname, 'static', 'storybook-static');
 
 const __docs = path.join(__dirname, 'docs');
 const __changelog = path.join(__docs, 'home', 'releases', 'changelog.md');
@@ -151,7 +153,25 @@ async function generateChangelog() {
   await fs.writeFile(__changelog, changelog);
 }
 
+async function copyStorybookBuild() {
+  if (!fs.existsSync(__storybookStatic)) {
+    console.error(
+      `Cannot copy Storybook build. Source folder not found: ${__storybookStatic}`
+    );
+    process.exit(1);
+  }
+
+  await fs.remove(__build);
+  await fs.copy(__storybookStatic, __build);
+  console.log(`Copied Storybook build to ${__build}`);
+}
+
 export default async function main() {
+  if (process.env.DOCS_DEPLOYMENT_TYPE === 'storybook') {
+    await copyStorybookBuild();
+    return;
+  }
+
   await downloadTheme();
   await generateChangelog();
   copyTheme();

--- a/scripts/copy-theme.ts
+++ b/scripts/copy-theme.ts
@@ -21,8 +21,6 @@ dotenv({
 
 const __dirname = path.resolve();
 const __node_modules = path.join(__dirname, 'node_modules');
-const __build = path.join(__dirname, 'build');
-const __storybookStatic = path.join(__dirname, 'static', 'storybook-static');
 
 const __docs = path.join(__dirname, 'docs');
 const __changelog = path.join(__docs, 'home', 'releases', 'changelog.md');
@@ -153,25 +151,7 @@ async function generateChangelog() {
   await fs.writeFile(__changelog, changelog);
 }
 
-async function copyStorybookBuild() {
-  if (!fs.existsSync(__storybookStatic)) {
-    console.error(
-      `Cannot copy Storybook build. Source folder not found: ${__storybookStatic}`
-    );
-    process.exit(1);
-  }
-
-  await fs.remove(__build);
-  await fs.copy(__storybookStatic, __build);
-  console.log(`Copied Storybook build to ${__build}`);
-}
-
 export default async function main() {
-  if (process.env.DOCS_DEPLOYMENT_TYPE === 'storybook') {
-    await copyStorybookBuild();
-    return;
-  }
-
   await downloadTheme();
   await generateChangelog();
   copyTheme();

--- a/scripts/prepare-markdown.ts
+++ b/scripts/prepare-markdown.ts
@@ -32,20 +32,14 @@ dotenv({
 const __temp = path.join(os.tmpdir(), 'ix-docs');
 const __promptDefaults = path.join(__temp, 'defaults.json');
 
+const __build = path.join(__dirname, 'build');
+const __storybookStatic = path.join(__dirname, 'static', 'storybook-static');
+
 type BranchConfig = {
   branch: string;
   branchType: 'main' | 'pull request' | (string & {});
   prNumber: string;
 };
-
-async function getDefaultFile() {
-  if (!(await fs.exists(__promptDefaults))) {
-    return {};
-  }
-
-  const defaults = JSON.parse(await fs.readFile(__promptDefaults, 'utf8'));
-  return defaults;
-}
 
 async function getDefaults(): Promise<BranchConfig> {
   let defaults: BranchConfig = {
@@ -62,7 +56,7 @@ async function getDefaults(): Promise<BranchConfig> {
     )
   ) {
     throw new Error(
-      'DOCS_BRANCH, DOCS_BRANCH_TYPE and DOCS_PR_NUMBER environment variables are required in CI.',
+      'DOCS_BRANCH, DOCS_BRANCH_TYPE and DOCS_PR_NUMBER environment variables are required in CI.'
     );
   }
 
@@ -88,10 +82,27 @@ async function main() {
   console.log(`Branch Type: ${defaults.branchType}`);
   console.log(`PR Number: ${defaults.prNumber}`);
 
-  await copyTheme();
-
   const branch = getBranch(defaults);
   await downloadLatestArtifact(branch);
+
+  if (process.env.DOCS_DEPLOYMENT_TYPE === 'storybook') {
+    await copyStorybookBuild();
+    return;
+  }
+  await copyTheme();
+}
+
+async function copyStorybookBuild() {
+  if (!fs.existsSync(__storybookStatic)) {
+    console.error(
+      `Cannot copy Storybook build. Source folder not found: ${__storybookStatic}`
+    );
+    process.exit(1);
+  }
+
+  await fs.remove(__build);
+  await fs.copy(__storybookStatic, __build);
+  console.log(`Copied Storybook build to ${__build}`);
 }
 
 function getBranch(config: BranchConfig) {
@@ -160,7 +171,7 @@ async function downloadLatestArtifact(branch: string) {
     .flatMap((run) => run.data.workflow_runs)
     .sort(
       (a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
     );
 
   if (
@@ -173,7 +184,7 @@ async function downloadLatestArtifact(branch: string) {
     throw new Error(message);
   }
   const runId = runs.filter(
-    (run) => run.name === 'Build' || run.name === 'Pull Request',
+    (run) => run.name === 'Build' || run.name === 'Pull Request'
   )[0].id;
 
   // Get artifacts for the run
@@ -189,7 +200,7 @@ async function downloadLatestArtifact(branch: string) {
   }
 
   const artifact = artifactsData.artifacts.find((artifact) =>
-    artifact.name.startsWith('documentation-'),
+    artifact.name.startsWith('documentation-')
   );
 
   if (!artifact) {
@@ -198,7 +209,7 @@ async function downloadLatestArtifact(branch: string) {
 
   console.log(
     `Downloading artifact: ${artifact.name} (ID: ${artifact.id})`,
-    artifact,
+    artifact
   );
 
   // Download the artifact zip


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 🆕 What is the new behavior?

If provided `DOCS_DEPLOYMENT_TYPE="storybook"` via `.env.production` or `.env.pullrequest` file the storybook of the target branch will be deployed as preview. 

Validation check inside branch build to avoid merging to main with storybook mode