### PR TITLE
docs(ix): fix typography API table token casing IX-3403

### DIFF
--- a/.env.pullrequest
+++ b/.env.pullrequest
@@ -1,0 +1,4 @@
+DOCS_BRANCH='main'
+DOCS_BRANCH_TYPE='pull request'
+
+DOCS_PR_NUMBER='2459'

--- a/.env.pullrequest
+++ b/.env.pullrequest
@@ -1,4 +1,0 @@
-DOCS_BRANCH='main'
-DOCS_BRANCH_TYPE='pull request'
-
-DOCS_PR_NUMBER='2459'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "typecheck": "tsc",
     "update-figma": "tsx ./scripts/download-figma-images.ts update"
   },

--- a/src/components/ApiTable/index.tsx
+++ b/src/components/ApiTable/index.tsx
@@ -11,23 +11,13 @@ import { useFramework } from '@site/src/hooks/use-framework';
 import clsx from 'clsx';
 import FrameworkSelection from '../UI/FrameworkSelection';
 import styles from './ApiTable.module.css';
+import { toKebabCase } from './toKebabCase';
 
 export type ApiTableProps = {
   readonly children?: React.ReactNode;
   readonly name: string;
   readonly type?: 'event' | 'property' | 'slot';
   readonly singleFramework?: boolean;
-};
-
-const toKebabCase = (str: string) => {
-  return str
-    .split('')
-    .map((letter, idx) => {
-      return letter.toUpperCase() === letter
-        ? `${idx !== 0 ? '-' : ''}${letter.toLowerCase()}`
-        : letter;
-    })
-    .join('');
 };
 
 function ApiTable({ children, id }) {

--- a/src/components/ApiTable/index.tsx
+++ b/src/components/ApiTable/index.tsx
@@ -10,8 +10,8 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import { useFramework } from '@site/src/hooks/use-framework';
 import clsx from 'clsx';
 import FrameworkSelection from '../UI/FrameworkSelection';
-import styles from './ApiTable.module.css';
 import { toKebabCase } from './toKebabCase';
+import styles from './ApiTable.module.css';
 
 export type ApiTableProps = {
   readonly children?: React.ReactNode;

--- a/src/components/ApiTable/toKebabCase.test.ts
+++ b/src/components/ApiTable/toKebabCase.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { toKebabCase } from './toKebabCase';
+
+test('#toKebabCase keeps kebab-case values unchanged', () => {
+  assert.equal(toKebabCase('title-content'), 'title-content');
+  assert.equal(toKebabCase('title-icon'), 'title-icon');
+});
+
+test('#toKebabCase converts camelCase to kebab-case', () => {
+  assert.equal(toKebabCase('titleContent'), 'title-content');
+  assert.equal(toKebabCase('myLongSlotName'), 'my-long-slot-name');
+});
+
+test('#toKebabCase handles PascalCase and non-letter separators safely', () => {
+  assert.equal(toKebabCase('TitleContent'), 'title-content');
+  assert.equal(toKebabCase('title_content'), 'title_content');
+  assert.equal(toKebabCase('title-content'), 'title-content');
+});
+
+test('#toKebabCase handles numbers and symbols without introducing extra dashes', () => {
+  assert.equal(toKebabCase('title2Content'), 'title2-content');
+  assert.equal(toKebabCase('Title2Content'), 'title2-content');
+  assert.equal(toKebabCase('title$content'), 'title$content');
+  assert.equal(toKebabCase('title$Content'), 'title$-content');
+  assert.equal(toKebabCase('title-content$Icon'), 'title-content$-icon');
+});
+
+test('#toKebabCase covers additional kebabize scenarios from camelCase examples', () => {
+  assert.equal(toKebabCase('camelCase'), 'camel-case');
+  assert.equal(toKebabCase('thisIsATest'), 'this-is-a-test');
+  assert.equal(toKebabCase('URLValue'), 'url-value');
+  assert.equal(toKebabCase('lowercase'), 'lowercase');
+  assert.equal(toKebabCase(''), '');
+  assert.equal(toKebabCase('already-kebab case'), 'already-kebab case');
+  assert.equal(toKebabCase(' leadingAndTrailing '), ' leading-and-trailing ');
+  assert.equal(toKebabCase('specialCharacters!@#'), 'special-characters!@#');
+  assert.equal(toKebabCase('stringWith1Number'), 'string-with1-number');
+});

--- a/src/components/ApiTable/toKebabCase.ts
+++ b/src/components/ApiTable/toKebabCase.ts
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const UPPERCASE_SEGMENT_REGEX = /[A-Z]+(?![a-z])|[A-Z]/g;
+
+export function toKebabCase(str: string): string {
+  return str.replace(UPPERCASE_SEGMENT_REGEX, (segment, offset) =>
+    `${offset ? '-' : ''}${segment.toLowerCase()}`
+  );
+}

--- a/src/components/TypographyTable/TypographyTable.module.css
+++ b/src/components/TypographyTable/TypographyTable.module.css
@@ -127,3 +127,12 @@
   background-color: transparent !important;
   padding-left: 0px;
 }
+
+
+.typographyFontFamilyValue {
+  text-transform: capitalize;
+}
+
+.typographyFontSizeValue {
+  text-transform: lowercase;
+}

--- a/src/components/TypographyTable/index.tsx
+++ b/src/components/TypographyTable/index.tsx
@@ -16,6 +16,7 @@ import {
 import { IxIcon, IxTypography } from '@siemens/ix-react';
 import ApiTable, { AnchorHeader } from '@site/src/components/ApiTable';
 import { useFramework } from '@site/src/hooks/use-framework';
+import { capitalize } from '@site/src/lib/utils/string-format';
 import CodeBlock from '@theme/CodeBlock';
 import clsx from 'clsx';
 import {
@@ -115,11 +116,6 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
 
   const themeRef = useRef<HTMLDivElement>();
 
-  /** Lowercase `--custom-property` token names in a resolved value (e.g. font stack). */
-  function normalizeTokenNamesInDisplay(value: string) {
-    return value.replace(/--[\w-]+/g, (token) => token.toLowerCase());
-  }
-
   function getCustomCSSValue(name: string) {
     const themeContainer = themeRef.current;
     if (!themeContainer) {
@@ -127,9 +123,9 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
     }
 
     const computedStyle = getComputedStyle(themeContainer);
-    const raw = computedStyle.getPropertyValue(name);
+    const colorHex = computedStyle.getPropertyValue(name);
 
-    return raw.trim();
+    return colorHex.toUpperCase();
   }
 
   useEffect(() => {
@@ -144,7 +140,7 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
     );
 
     let [_, fontWeight, fontSize, lineHeight, fontFamily] = regexResult;
-    const displayName = typographyName;
+    const displayName = capitalize(typographyName, true);
 
     if (!lineHeight.includes('%')) {
       lineHeight = (parseFloat(lineHeight) * 100).toString();
@@ -153,7 +149,7 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
     return {
       displayName,
       name,
-      fontFamily: normalizeTokenNamesInDisplay(fontFamily),
+      fontFamily,
       fontSize,
       fontWeight,
       lineHeight,

--- a/src/components/TypographyTable/index.tsx
+++ b/src/components/TypographyTable/index.tsx
@@ -16,7 +16,6 @@ import {
 import { IxIcon, IxTypography } from '@siemens/ix-react';
 import ApiTable, { AnchorHeader } from '@site/src/components/ApiTable';
 import { useFramework } from '@site/src/hooks/use-framework';
-import { capitalize } from '@site/src/lib/utils/string-format';
 import CodeBlock from '@theme/CodeBlock';
 import clsx from 'clsx';
 import {
@@ -116,6 +115,11 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
 
   const themeRef = useRef<HTMLDivElement>();
 
+  /** Lowercase `--custom-property` token names in a resolved value (e.g. font stack). */
+  function normalizeTokenNamesInDisplay(value: string) {
+    return value.replace(/--[\w-]+/g, (token) => token.toLowerCase());
+  }
+
   function getCustomCSSValue(name: string) {
     const themeContainer = themeRef.current;
     if (!themeContainer) {
@@ -123,9 +127,9 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
     }
 
     const computedStyle = getComputedStyle(themeContainer);
-    const colorHex = computedStyle.getPropertyValue(name);
+    const raw = computedStyle.getPropertyValue(name);
 
-    return colorHex.toUpperCase();
+    return raw.trim();
   }
 
   useEffect(() => {
@@ -140,7 +144,7 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
     );
 
     let [_, fontWeight, fontSize, lineHeight, fontFamily] = regexResult;
-    const displayName = capitalize(typographyName, true);
+    const displayName = typographyName;
 
     if (!lineHeight.includes('%')) {
       lineHeight = (parseFloat(lineHeight) * 100).toString();
@@ -149,7 +153,7 @@ function BrowserOnlyTypographyTable({ children, typographyName }) {
     return {
       displayName,
       name,
-      fontFamily,
+      fontFamily: normalizeTokenNamesInDisplay(fontFamily),
       fontSize,
       fontWeight,
       lineHeight,

--- a/src/components/TypographyTable/index.tsx
+++ b/src/components/TypographyTable/index.tsx
@@ -280,7 +280,9 @@ function TypographyStyle() {
               styles.typographyColumnChildName
             )}
           >
-            <code>{typography.fontFamily}</code>
+            <code className={styles.typographyFontFamilyValue}>
+              {typography.fontFamily.toLowerCase()}
+            </code>
           </div>
         </div>
       </TypographyTable.Text>
@@ -293,7 +295,9 @@ function TypographyStyle() {
               styles.typographyColumnChildName
             )}
           >
-            <code>{typography.fontSize}</code>
+            <code className={styles.typographyFontSizeValue}>
+              {typography.fontSize}
+            </code>
           </div>
         </div>
       </TypographyTable.Text>


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

On **Styles → Typography**, the usage tables showed **Font family** and **Font size** in a harsh, non–documentation-friendly form (for example all-caps family names and uppercase **REM**), which does not match the guideline to present typography token values in a readable, conventional way.

GitHub Issue Number: #<ISSUE NUMBER>

## 🆕 What is the new behavior?

- **Font family:** the value cell uses **`text-transform: capitalize`** in CSS and **`toLowerCase()`** in JSX so names read in a natural title-style casing (e.g. **"Siemens Sans"** instead of **"SIEMENS SANS"**).
- **Font size:** the value cell uses **`text-transform: lowercase`** so the **rem** unit appears in standard CSS form (e.g. **1.8125rem**).
