### PR TITLE
fix: quote the time formats colon :mm: to avoid flag rendering

### DIFF
--- a/docs/guidelines/language/formatting/timezones.mdx
+++ b/docs/guidelines/language/formatting/timezones.mdx
@@ -35,7 +35,7 @@ Use colons (:) to split times between hours, minutes, and seconds.
 <div className="dos-and-donts" markdown="true">
 <div className="dos" markdown="true">
 
-- hh:mm:ss
+- hh\:mm\:ss
 
 </div>
 <div className="donts" markdown="true">
@@ -50,8 +50,8 @@ Use periods (.) to add milliseconds and nanoseconds, not a colon (:) according t
 <div className="dos-and-donts" markdown="true">
 <div className="dos" markdown="true">
 
-- hh:mm:ss.mms
-- hh:mm:ss.sss (ISO 8601 standard)
+- hh\:mm\:ss.mms
+- hh\:mm\:ss.sss (ISO 8601 standard)
 - 0:00:00.920
 
 </div>


### PR DESCRIPTION
The format :mm: is interpreted as a flag when the markdown plugins are available. Quoting \:mm\: helps.

<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

We use the same source to render the docs in other markdown systems.
Parts of the format hh:mm:ss is rendered as a flag. To avoid fixing it after every
sync, we should also fix it as the source.

<img width="1341" height="557" alt="Screenshot 2026-03-26 at 13 52 25" src="https://github.com/user-attachments/assets/bcfcc7aa-4006-468d-ab89-f371b12d30d3" />


## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Quoting the colo \: makes sue to keep it.
-

## 👨‍💻 Help & support


<!-- If you need help with anything related to your PR please let us know in this section -->
