### PR TITLE
fix: make marketing pill more accessible

### DIFF
--- a/src/components/theme/NewsPill/NewsPill.module.css
+++ b/src/components/theme/NewsPill/NewsPill.module.css
@@ -30,7 +30,7 @@
 }
 
 @media screen and (max-width: 1415px) {
-  .NewsPill {
+  a {
     display: none;
   }
 }

--- a/src/components/theme/NewsPill/NewsPill.module.css
+++ b/src/components/theme/NewsPill/NewsPill.module.css
@@ -30,7 +30,7 @@
 }
 
 @media screen and (max-width: 1415px) {
-  a {
+  .NoTextDecoration {
     display: none;
   }
 }

--- a/src/components/theme/NewsPill/index.tsx
+++ b/src/components/theme/NewsPill/index.tsx
@@ -13,7 +13,7 @@ import Link from '@docusaurus/Link';
 
 export default function NewsPill({ label, value }) {
   return (
-    <Link to={value} className={styles.NoTextDecoration}>
+    <Link to={value} className={styles.NoTextDecoration} aria-label={label}>
       <div className={styles.NewsPill}>
         <IxTypography format="body-sm" bold>
           {label}


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Marketing pill has no descriptive ARIA label and will still be focusable even if hidden via RWD.

GitHub Issue Number: IX-4110

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Set ARIA-label
- Hide whole element so it can no longer be focused on smaller layouts

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
