### PR TITLE
migration guide update

### DIFF
--- a/docs/home/migration/5_0_0/index.md
+++ b/docs/home/migration/5_0_0/index.md
@@ -20,7 +20,7 @@ This section gives an overview of the main code-level breaking changes in Versio
 
 We optimized our [Breaking changes guide](https://github.com/siemens/ix/blob/main/BREAKING_CHANGES/v5.md) with a clear structure that is easy to parse both for humans and AI agents.
 
-It starts with a high-level title and then splits the migration into isolated change domains, e.g. button accessibility, theming, [ix-application](/docs/components/application), [ix-toast](/docs/components/toast), and [ix-modals](/docs/components/modal). Within each domain, the guide follows a repeatable pattern:
+It starts with a high-level title and then splits the migration into isolated change domains, e.g. button accessibility, theming, [ix-application](/docs/components/application), [ix-breadcrumb](/docs/components/breadcrumb), [ix-tabs](/docs/components/tabs), [ix-toast](/docs/components/toast), and [ix-modals](/docs/components/modal). Within each domain, the guide follows a repeatable pattern:
 
 - A short explanation of what changed and why
 - Exact API or attribute names that were removed, added or renamed
@@ -38,21 +38,28 @@ We recommend migrating V4 to V5 section by section, following the [Breaking chan
 
 This domain-by-domain approach is preferred over an all-at-once rewrite because it keeps changes reviewable, reduces migration risk, and makes automated transformations easier to verify.
 
-### Deprecated and removed components
+### Deprecated and removed components and APIs
 
 Version 5 removes several legacy APIs and attributes that were kept for backwards compatibility in earlier releases.
 
 - We removed legacy accessibility label properties on button-related components. Use native `aria-label` on the host element instead.
 - `ix-modal` no longer supports `disableEscapeClose`. Use `beforeDismiss` to control whether a modal can be dismissed.
+- `showModal()` and `ModalConfig` no longer support the no-op `container`, `keyboard`, and `title` options. Remove them and define titles in the modal content instead.
 - `ix-toast-container` no longer creates a separate wrapper element in `document.body`. The host element is now the container.
+- `ix-split-button` no longer supports the `placement` property because it did not affect dropdown positioning.
 
 ### Component updates
 
 Several existing components now follow clearer and more consistent API patterns in Version 5.
 
+- `ix-breadcrumb` now requires stable `breadcrumbKey` values on items. `nextItems` also use objects with `label` and `breadcrumbKey`, and click payloads now expose the key.
+- `ix-card-list` now reveals all hidden cards by default when the show-all or show-more action is triggered. If you previously implemented custom reveal behavior, call `preventDefault()` in the event handler.
 - `ix-time-picker` renames the `i18n-column-header` attribute to `i18n-hour-column-header` to align with the rest of the time-related API.
+- `ix-tabs` changed from index-based selection to key-based selection. Replace `selected` with `activeTabKey`, `selectedChange` with `tabChange`, and add a unique `tabKey` to every tab item.
+- `ix-menu-about` and `ix-menu-settings` now use tab keys consistently. New slotted `ix-tabs` integrations require `suppressLegacyTabs`, and `ix-menu-about-news` replaces `about-item-label` with `activeAboutTabKey`.
 - `ThemeSwitcher` now uses the new theme and color schema model and updates its event payloads accordingly.
 - `ix-application` now separates the theme name from the color schema, replacing combined values, e.g. `classic-dark`.
+- `@siemens/ix-aggrid` now expects `@siemens/ix` as a direct dependency in the consuming application.
 
 ### Global style updates
 
@@ -60,6 +67,7 @@ Theming is the largest migration topic in Version 5.
 
 - We replaced legacy classes, e.g. `theme-classic-light` and `theme-classic-dark`, with `data-ix-theme` and `data-ix-color-schema` on the `html` element.
 - iX no longer injects a default theme automatically, so applications should set both attributes explicitly if a default theme is required.
+- `ThemeSwitcher` is now fully aligned with the split theme model: replace `setVariant()` with `setColorSchema()`, `schemaChanged` with `themeChanged`, and update handlers to read the new object payload.
 - The remaining Bootstrap font variable has been removed. If your application still relies on it, map `--bs-font-sans-serif` to `var(--theme-font-family)`.
 
 ## What changed in the Figma library
@@ -103,5 +111,5 @@ The following components were fully removed from the library after prior depreca
 Please check out the following resources and don’t hesitate to [contact us](./../support/contact-us) if you have further questions or migration problems.
 
 - [Release V5.0.0 blog post](/blog/2026/05/11/release-5)
-- [Breaking Changes guide](https://github.com/siemens/ix/blob/release-5.0.0/BREAKING_CHANGES/v5.md)
+- [Breaking Changes guide](https://github.com/siemens/ix/blob/main/BREAKING_CHANGES/v5.md)
 - [Changelog](https://github.com/siemens/ix/releases)

--- a/docs/home/migration/5_0_0/index.md
+++ b/docs/home/migration/5_0_0/index.md
@@ -38,7 +38,7 @@ We recommend migrating V4 to V5 section by section, following the [Breaking chan
 
 This domain-by-domain approach is preferred over an all-at-once rewrite because it keeps changes reviewable, reduces migration risk, and makes automated transformations easier to verify.
 
-### Deprecated and removed components and APIs
+### Deprecated and removed components and API resources
 
 Version 5 removes several legacy APIs and attributes that were kept for backwards compatibility in earlier releases.
 

--- a/docs/home/releases/release-version.md
+++ b/docs/home/releases/release-version.md
@@ -40,13 +40,13 @@ All major releases receive support for approximately 12 months. We distinguish b
 
 Our support policy applies to all components of the design system including the code base, Figma design kits and our documentation.
 
-We recommend always following the active release. When a version moves from the active stage to the LTS stage, projects should start migrating to the new active major version.
+We recommend always following the active release. When a version moves from the active stage to the Maintenance stage, projects should start migrating to the new active major version.
 
 ## Supported versions
 
-| Version |   Status    | Released       | Maintenance support since | End of life since |
+| Version |   Status    | Latest       | Maintenance support | End of life |
 | ------- | :---------: | -------------- | ------------------------- | ----------------- |
-| V5.0.0  |    Next     | ~ May 2026     | -                         | -                 |
-| V4.0.0  |   Latest    | November 2025  | ~ May 2026                | ~ November 2026   |
-| V3.0.0  | Maintenance | May 2025       | November 2025             | May 2026          |
-| V2.0.0  | End of Life | September 2023 | May 2025                  | November 2025     |
+| V5.0.0  |        Latest       | 2026-05 - 2026-11 | 2026-11 - 2027-05 | 2027-05 |
+| V4.0.0  |     Maintenance     | 2025-11 - 2026-05 | 2026-05 - 2026-11 | 2026-11 |
+| V3.0.0  |     End of Life     | 2025-05 - 2025-11 | 2025-11 - 2026-05 | 2026-05 |
+| V2.0.0  |     End of Life     | 2023-09 - 2025-05 | 2025-05 - 2025-11 | 2025-11 |

--- a/docs/home/releases/release-version.md
+++ b/docs/home/releases/release-version.md
@@ -40,7 +40,7 @@ All major releases receive support for approximately 12 months. We distinguish b
 
 Our support policy applies to all components of the design system including the code base, Figma design kits and our documentation.
 
-We recommend always following the active release. When a version moves from the active stage to the Maintenance stage, projects should start migrating to the new active major version.
+We recommend always following the active release. When a version moves from the active stage to the maintenance stage, projects should start migrating to the new active major version.
 
 ## Supported versions
 

--- a/version-deployment.json
+++ b/version-deployment.json
@@ -6,13 +6,13 @@
       "id": "v5",
       "href": "https://ix.siemens.io",
       "label": "Version 5",
-      "dropdownLabel": "Version 5"
+      "dropdownLabel": "Version 5 (latest)"
     },
     {
       "id": "v4",
       "href": "https://ix.siemens.io",
       "label": "Version 4",
-      "dropdownLabel": "Version 4 (latest)"
+      "dropdownLabel": "Version 4"
     },
     {
       "id": "v3",

--- a/version-deployment.json
+++ b/version-deployment.json
@@ -1,5 +1,5 @@
 {
-  "latestVersion": "v4",
+  "latestVersion": "v5",
   "currentVersion": "v5",
   "versions": [
     {


### PR DESCRIPTION
## 💡 What is the current behavior?

- migration guide not up to date with latest changes
- versioning info not adapted to v5

## 🆕 What is the new behavior?

- updated migration guide
- updated versioning
- updated version dropdown in header

