### PR TITLE
fix: convert markdown dos and don's into ul with aria-label

### DIFF
--- a/docs/components/3d/overview.mdx
+++ b/docs/components/3d/overview.mdx
@@ -28,6 +28,16 @@ import 'echarts-gl';
 
 ## Dos and Don’ts
 
-- Do use with data that's best seen and interpreted in multiple dimensions
-- Don’t use 3D charts for simple data that can be effectively represented with 2D charts
-- Don’t overuse 3D charts as they can make the data harder to interpret
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use with data that's best seen and interpreted in multiple dimensions</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use 3D charts for simple data that can be effectively represented with 2D charts</li>
+      <li>Don’t overuse 3D charts as they can make the data harder to interpret</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/application-header/guide.md
+++ b/docs/components/application-header/guide.md
@@ -126,9 +126,19 @@ At breakpoint "sm" the layout changes in the following way:
 
 ## Dos and Don’ts
 
-- Do align other slot usages for Siemens applications with our team to keep a consistent look and feel
-- Do use the avatar dropdown for actions related to the current logged in user
-- Do test layout behavior at all breakpoints to ensure content remains accessible
-- Don’t overload the slots with too many elements to avoid losing clarity and hierarchy
-- Don’t use the avatar if your application does not support user profiles
-- Don’t rely on automatic overflow handling for complex layouts, instead reduce complexity
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do align other slot usages for Siemens applications with our team to keep a consistent look and feel</li>
+      <li>Do use the avatar dropdown for actions related to the current logged in user</li>
+      <li>Do test layout behavior at all breakpoints to ensure content remains accessible</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t overload the slots with too many elements to avoid losing clarity and hierarchy</li>
+      <li>Don’t use the avatar if your application does not support user profiles</li>
+      <li>Don’t rely on automatic overflow handling for complex layouts, instead reduce complexity</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/application-menu/guide.md
+++ b/docs/components/application-menu/guide.md
@@ -44,8 +44,18 @@ The navigation menu is an essential part of your application. It offers a way to
 The application menu has two states: collapsed and expanded. The appearance of the states varies between screen sizes.
 ## Dos and Don’ts
 
-- Do use icons in second-level navigation items when it helps users to better understand and recognize them
-- Do use a custom tooltip text if the label is so long that it gets truncated or needs additional context
-- Don’t mix menu items with and without icons within a second-level navigation category
-- Don’t place non-navigational items in the navigation section
-- Don’t place navigation items in the bottom section as items in the bottom section must not navigate away from the current context
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use icons in second-level navigation items when it helps users to better understand and recognize them</li>
+      <li>Do use a custom tooltip text if the label is so long that it gets truncated or needs additional context</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t mix menu items with and without icons within a second-level navigation category</li>
+      <li>Don’t place non-navigational items in the navigation section</li>
+      <li>Don’t place navigation items in the bottom section as items in the bottom section must not navigate away from the current context</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/avatar/guide.md
+++ b/docs/components/avatar/guide.md
@@ -24,4 +24,10 @@ The avatar is a display-only component with no further interactions. Images prov
 
 ![Avatar dos and don‘ts](https://www.figma.com/design/wEptRgAezDU1z80Cn3eZ0o/iX-Pattern-Illustrations?type=design&node-id=975-13&mode=design&t=SxUA6AcHswBAiIzi-4)
 
-- Don’t use more than 2 characters when using the "Initials" option
+<div class="dos-and-donts">
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don't use more than 2 characters when using the "Initials" option</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/bar-chart/overview.mdx
+++ b/docs/components/bar-chart/overview.mdx
@@ -24,10 +24,20 @@ Stacked bar charts are typically used to visualize the relationship between the 
 
 ## Dos and Don’ts
 
-- Do start the Y-axis at zero and label axes clearly
-- Do use short and clear category names
-- Do include context and additional information when necessary
-- Do arrange categories and bars in a logical order
-- Don’t use too many bars in one chart
-- Don’t overcrowd charts with colors and categories, especially the stacked variant
-- Don’t use stacked bars if the total value is not important
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do start the Y-axis at zero and label axes clearly</li>
+      <li>Do use short and clear category names</li>
+      <li>Do include context and additional information when necessary</li>
+      <li>Do arrange categories and bars in a logical order</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use too many bars in one chart</li>
+      <li>Don’t overcrowd charts with colors and categories, especially the stacked variant</li>
+      <li>Don’t use stacked bars if the total value is not important</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/blind/guide.md
+++ b/docs/components/blind/guide.md
@@ -49,11 +49,21 @@ For all blind variants, a default, hover, active and focused state is available.
 
 ## Dos and Don’ts
 
-- Do stay within the recommended number of blinds - between 3 and 7
-- Don’t use multi-line text in the header. The header section has a fixed height for single-line text entries
-- Don’t change the position of the chevron icon and the blind's label in the header
-- Don’t use a blind if there is only a single category to be displayed
-- Don’t use blinds to display hierarchically structured files or objects - rather use a tree for such cases
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do stay within the recommended number of blinds - between 3 and 7</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use multi-line text in the header. The header section has a fixed height for single-line text entries</li>
+      <li>Don’t change the position of the chevron icon and the blind's label in the header</li>
+      <li>Don’t use a blind if there is only a single category to be displayed</li>
+      <li>Don’t use blinds to display hierarchically structured files or objects - rather use a tree for such cases</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/breadcrumb/guide.md
+++ b/docs/components/breadcrumb/guide.md
@@ -40,10 +40,20 @@ Interactive items can take one of four states: Default, hover, active and focuse
 
 ## Dos and Don’ts
 
-- Do label each item, i.e. use more than icons
-- Do use single-line text entries as breadcrumb items have a fixed height
-- Don’t use breadcrumbs to display a multistep process (use the [workflow](../workflow) control instead)
-- Don’t show multiple breadcrumbs on one screen, e.g. in a content area and in a drawer
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do label each item, i.e. use more than icons</li>
+      <li>Do use single-line text entries as breadcrumb items have a fixed height</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use breadcrumbs to display a multistep process (use the [workflow](../workflow) control instead)</li>
+      <li>Don’t show multiple breadcrumbs on one screen, e.g. in a content area and in a drawer</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/button/guide.md
+++ b/docs/components/button/guide.md
@@ -49,12 +49,22 @@ Buttons have six states: Default, hover, active, disabled, loading and focused. 
 
 ## Dos and Don’ts
 
-- Do use short button labels to allow users to quickly scan, understand and remember them (see our [writing style guide](../../guidelines/language/dialogs-and-buttons.md))
-- Do use ellipsis (…) to indicate that an action requires further input or choice from the user, e.g. "Save as…" which opens a list of file types to choose from
-- Do use the primary variant for buttons to indicate one primary action in a visual unit, all other secondary actions should use the secondary variant
-- Don’t place icons both left and right of the label on the same button
-- Don’t use the danger button excessively or repetitively in lists or tables
-- Don’t rely on standard buttons when many actions are necessary (use [dropdown buttons](../dropdown-button/index.mdx) or [split buttons](../split-button/index.mdx) instead, or move some functionality to a [pane](../panes/index.mdx) or a [dialog](../modal/index.mdx))
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use short button labels to allow users to quickly scan, understand and remember them (see our [writing style guide](../../guidelines/language/dialogs-and-buttons.md))</li>
+      <li>Do use ellipsis (…) to indicate that an action requires further input or choice from the user, e.g. "Save as…" which opens a list of file types to choose from</li>
+      <li>Do use the primary variant for buttons to indicate one primary action in a visual unit, all other secondary actions should use the secondary variant</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t place icons both left and right of the label on the same button</li>
+      <li>Don’t use the danger button excessively or repetitively in lists or tables</li>
+      <li>Don’t rely on standard buttons when many actions are necessary (use [dropdown buttons](../dropdown-button/index.mdx) or [split buttons](../split-button/index.mdx) instead, or move some functionality to a [pane](../panes/index.mdx) or a [dialog](../modal/index.mdx))</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/card-list/guide.md
+++ b/docs/components/card-list/guide.md
@@ -43,9 +43,19 @@ The scroll card list style displays the content items from left to right next to
 
 ## Dos and Don’ts
 
-- Do keep cards and items within card lists the same size
-- Don’t place different types of components within card lists
-- Don’t nest card lists within each other
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do keep cards and items within card lists the same size</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t place different types of components within card lists</li>
+      <li>Don’t nest card lists within each other</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/card/guide.md
+++ b/docs/components/card/guide.md
@@ -83,10 +83,20 @@ Cards have four states: Default, hover, active and focused.
 
 ## Dos and Don’ts
 
-- Do group cards in [card lists](../card-list) or [grids](../grid)
-- Do keep multiple cards equal in size
-- Don’t nest cards inside each other
-- Don’t use cards to collect user input
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do group cards in [card lists](../card-list) or [grids](../grid)</li>
+      <li>Do keep multiple cards equal in size</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t nest cards inside each other</li>
+      <li>Don’t use cards to collect user input</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/category-filter/guide.md
+++ b/docs/components/category-filter/guide.md
@@ -45,14 +45,24 @@ Category filter has six states: Default, hover, active, disabled, read-only and 
 
 ## Dos and Don’ts
 
-- Do use if you have a large amount of content or products organized into different categories
-- Do use when catering to a diverse user base with different interests or needs
-- Do use if your content or products are organized into distinct categories or topics
-- Do use to make it easier for users to refine their search queries and receive more targeted results
-- Don’t use if your content is minimal or not organized into distinct categories
-- Don’t use if it’s not the primary method of navigation
-- Don’t use if it slows down the user experience
-- Don’t use if your users are not familiar with the category names
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use if you have a large amount of content or products organized into different categories</li>
+      <li>Do use when catering to a diverse user base with different interests or needs</li>
+      <li>Do use if your content or products are organized into distinct categories or topics</li>
+      <li>Do use to make it easier for users to refine their search queries and receive more targeted results</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use if your content is minimal or not organized into distinct categories</li>
+      <li>Don’t use if it’s not the primary method of navigation</li>
+      <li>Don’t use if it slows down the user experience</li>
+      <li>Don’t use if your users are not familiar with the category names</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/checkbox/guide.md
+++ b/docs/components/checkbox/guide.md
@@ -36,9 +36,19 @@ Checkboxes are commonly used when there are multiple options that can be selecte
 
 ## Dos and Don’ts
 
-- Do use checkboxes when you have multiple options that can be selected
-- Do group related checkboxes together to indicate their relationship
-- Do use checkboxes in forms to allow users to select multiple options
-- Don’t use a checkbox for binary choices (yes/no, true/false) - use a toggle switch instead
-- Don’t use checkboxes for mutually exclusive options - use [radio buttons](../radio) instead
-- Don’t use checkboxes for actions that have immediate consequences - use [buttons](../button) or links instead
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use checkboxes when you have multiple options that can be selected</li>
+      <li>Do group related checkboxes together to indicate their relationship</li>
+      <li>Do use checkboxes in forms to allow users to select multiple options</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use a checkbox for binary choices (yes/no, true/false) - use a toggle switch instead</li>
+      <li>Don’t use checkboxes for mutually exclusive options - use [radio buttons](../radio) instead</li>
+      <li>Don’t use checkboxes for actions that have immediate consequences - use [buttons](../button) or links instead</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/chip/guide.md
+++ b/docs/components/chip/guide.md
@@ -52,12 +52,22 @@ Chips take a default, hover, focused or active state with a varying background c
 
 ## Dos and Don’ts
 
-- Do use chips to tag and categorize so users can easily organize and filter content
-- Do ensure proper color contrast between chip background and text/icon with the custom variant to support readability
-- Do consider chip spacing for easy tapping or selecting with mobiles and desktops
-- Don’t overuse chips as this leads to cluttered and overwhelming interfaces
-- Don’t use different styles for chips with the same or similar use
-- Don’t use chips without any interaction (we recommend pills instead)
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use chips to tag and categorize so users can easily organize and filter content</li>
+      <li>Do ensure proper color contrast between chip background and text/icon with the custom variant to support readability</li>
+      <li>Do consider chip spacing for easy tapping or selecting with mobiles and desktops</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t overuse chips as this leads to cluttered and overwhelming interfaces</li>
+      <li>Don’t use different styles for chips with the same or similar use</li>
+      <li>Don’t use chips without any interaction (we recommend pills instead)</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/content-header/guide.md
+++ b/docs/components/content-header/guide.md
@@ -42,10 +42,20 @@ Our content header variants makes it easier to achieve a well-balanced visual hi
 
 ## Dos and Don’ts
 
-- Do use to provide quick access to common tasks for the whole content area
-- Do place only items in the header slot that don’t take up too much space, such as a status or a counter
-- Don’t use a secondary content header as a page title
-- Don’t use more than one primary headline in one page
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use to provide quick access to common tasks for the whole content area</li>
+      <li>Do place only items in the header slot that don’t take up too much space, such as a status or a counter</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use a secondary content header as a page title</li>
+      <li>Don’t use more than one primary headline in one page</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/custom-field/guide.md
+++ b/docs/components/custom-field/guide.md
@@ -34,11 +34,21 @@ The states depend on the component that you use in the custom field. The custom
 
 ## Dos and Don’ts
 
-- Do use the custom field when your desired solution is not covered by the already existing form field components
-- Do use the custom field in combination with the form component to create complex forms
-- Don’t use the custom field for simple form fields, use the form field component instead
-- Don’t use the custom field without a form component, it is a wrapper component that is meant to be used in combination with the form component
-- Don’t use helper and feedback texts for single fields within a custom field, use the helper and feedback text of the whole custom field instead
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use the custom field when your desired solution is not covered by the already existing form field components</li>
+      <li>Do use the custom field in combination with the form component to create complex forms</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use the custom field for simple form fields, use the form field component instead</li>
+      <li>Don’t use the custom field without a form component, it is a wrapper component that is meant to be used in combination with the form component</li>
+      <li>Don’t use helper and feedback texts for single fields within a custom field, use the helper and feedback text of the whole custom field instead</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/date-picker/guide.mdx
+++ b/docs/components/date-picker/guide.mdx
@@ -40,22 +40,22 @@ Individual calendar dates within a date picker have five states: Default, hover,
 
 ## Dos and Don’ts
 
-<div class="dos-and-donts" markdown>
-<div class="dos" markdown>
-
-- Do use date pickers to ensure accurate date selection
-- Do provide clear labels when the date picker is used in a form context
-- Do ensure the date picker is accessible via keyboard navigation
-- Do use range selection for date periods like booking dates or report timeframes
-- Do set min and max dates to prevent invalid date selections
-
+<div class="dos-and-donts">
+<div class="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do use date pickers to ensure accurate date selection</li>
+    <li>Do provide clear labels when the date picker is used in a form context</li>
+    <li>Do ensure the date picker is accessible via keyboard navigation</li>
+    <li>Do use range selection for date periods like booking dates or report timeframes</li>
+    <li>Do set min and max dates to prevent invalid date selections</li>
+  </ul>
 </div>
-<div class="donts" markdown>
-
-- Don’t use date pickers for dates that are far in the past or future, use [date inputs](../input) instead
-- Don’t clutter the date picker interface with unnecessary options
-- Don’t forget to handle empty or invalid date states in your validation logic
-
+<div class="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don’t use date pickers for dates that are far in the past or future, use [date inputs](../input) instead</li>
+    <li>Don’t clutter the date picker interface with unnecessary options</li>
+    <li>Don’t forget to handle empty or invalid date states in your validation logic</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/date-time-picker/guide.mdx
+++ b/docs/components/date-time-picker/guide.mdx
@@ -41,22 +41,22 @@ Individual calendar dates within a date time picker have five states: Default, h
 
 ## Dos and Don’ts
 
-<div class="dos-and-donts" markdown>
-<div class="dos" markdown>
-
-- Do use date time pickers when both date and time information are required
-- Do ensure the date time picker is accessible via keyboard navigation
-- Do use range selection for time periods like booking appointments or scheduling events
-- Do set appropriate min and max dates to prevent invalid selections
-
+<div class="dos-and-donts">
+<div class="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do use date time pickers when both date and time information are required</li>
+    <li>Do ensure the date time picker is accessible via keyboard navigation</li>
+    <li>Do use range selection for time periods like booking appointments or scheduling events</li>
+    <li>Do set appropriate min and max dates to prevent invalid selections</li>
+  </ul>
 </div>
-<div class="donts" markdown>
-
-- Don’t use date time pickers when only a date or only a time is needed (use [date pickers](../date-picker) or [time pickers](../time-picker) instead)
-- Don’t forget to validate both date and time inputs in your form logic
-- Don’t use date time pickers for dates that are far in the past or future without setting appropriate min and max constraints
-- Don’t clutter the interface with unnecessary time precision when approximate times are sufficient
-
+<div class="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don’t use date time pickers when only a date or only a time is needed (use [date pickers](../date-picker) or [time pickers](../time-picker) instead)</li>
+    <li>Don’t forget to validate both date and time inputs in your form logic</li>
+    <li>Don’t use date time pickers for dates that are far in the past or future without setting appropriate min and max constraints</li>
+    <li>Don’t clutter the interface with unnecessary time precision when approximate times are sufficient</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/dropdown-button/guide.md
+++ b/docs/components/dropdown-button/guide.md
@@ -34,8 +34,18 @@ Dropdown buttons have five states: Default, hover, active, disabled and focused.
 
 ## Dos and Don’ts
 
-- Do use dropdown buttons when selecting an option triggers an action
-- Don’t use dropdown buttons when there is a frequent or most-important action (use a standard button or a split button instead)
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use dropdown buttons when selecting an option triggers an action</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use dropdown buttons when there is a frequent or most-important action (use a standard button or a split button instead)</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/dropdown/guide.md
+++ b/docs/components/dropdown/guide.md
@@ -56,12 +56,22 @@ Dropdown items have five states: Default, hover, active, disabled and focused. W
 
 ## Dos and Don’ts
 
-- Do structure dropdown items coherently with submenus, quick actions and separators
-- Do use dropdowns to showcase related actions
-- Do disable items that cannot be used at that moment
-- Don’t use global navigation options in a dropdown
-- Don’t use too many dropdown items - we recommend a maximum of seven
-- Don’t insert the [date picker](../date-dropdown) instead)
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do structure dropdown items coherently with submenus, quick actions and separators</li>
+      <li>Do use dropdowns to showcase related actions</li>
+      <li>Do disable items that cannot be used at that moment</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use global navigation options in a dropdown</li>
+      <li>Don’t use too many dropdown items - we recommend a maximum of seven</li>
+      <li>Don’t insert the [date picker](../date-dropdown) instead)</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/forms-field/guide.md
+++ b/docs/components/forms-field/guide.md
@@ -43,11 +43,21 @@ When a feedback tooltip is chosen over a message, the field shows a tooltip when
 
 ## Dos and Don’ts
 
-- Do use a label for every field
-- Do use a counter for fields with a character limit
-- Do use helper text to provide additional information or context about the field
-- Don’t use helper text as a replacement for clear labels
-- Don’t mix different variants of feedback text and tooltips
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use a label for every field</li>
+      <li>Do use a counter for fields with a character limit</li>
+      <li>Do use helper text to provide additional information or context about the field</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use helper text as a replacement for clear labels</li>
+      <li>Don’t mix different variants of feedback text and tooltips</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/forms-validation/guide.md
+++ b/docs/components/forms-validation/guide.md
@@ -67,9 +67,19 @@ Example: When the user completes the shipping address section of an e-commerce c
 
 ## Dos and Don’ts
 
-- Do use short and helpful copy for validation
-- Do include all relevant information in the validation message, including context
-- Don’t show valid feedback on components, only in the input help component
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use short and helpful copy for validation</li>
+      <li>Do include all relevant information in the validation message, including context</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t show valid feedback on components, only in the input help component</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/gauge-chart/overview.mdx
+++ b/docs/components/gauge-chart/overview.mdx
@@ -31,9 +31,19 @@ Arc gauge charts, also known as semi-circular progress bars, are a dynamic way t
 
 ## Dos and Don’ts
 
-- Do keep it simple and easy to read, with a clear needle and well-defined ranges
-- Do use color coding, e.g. green for good, red for danger, etc. to indicate different ranges
-- Do label ranges and the needle value clearly to avoid confusion
-- Don’t overcrowd the gauge with too many ranges or labels
-- Don’t use gauge charts for visualizing complex data or large datasets
-- Don’t use similar colors for adjacent ranges to avoid confusion
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do keep it simple and easy to read, with a clear needle and well-defined ranges</li>
+      <li>Do use color coding, e.g. green for good, red for danger, etc. to indicate different ranges</li>
+      <li>Do label ranges and the needle value clearly to avoid confusion</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t overcrowd the gauge with too many ranges or labels</li>
+      <li>Don’t use gauge charts for visualizing complex data or large datasets</li>
+      <li>Don’t use similar colors for adjacent ranges to avoid confusion</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/grid/guide.md
+++ b/docs/components/grid/guide.md
@@ -49,11 +49,21 @@ Data grid columns, rows and cells have multiple states: Default, hover, active a
 
 ## Dos and Don’ts
 
-- Do only display primary information by default and use [column tool panels](https://www.ag-grid.com/javascript-data-grid/tool-panel-columns/) for secondary information
-- Do keep selection and row-click behavior independent to avoid confusion
-- Do design responsive layouts that adapt to different screen sizes
-- Don’t embed heavily interactive components within grid cells
-- Don’t rely solely on color for status, use icons, labels or badges instead
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do only display primary information by default and use [column tool panels](https://www.ag-grid.com/javascript-data-grid/tool-panel-columns/) for secondary information</li>
+      <li>Do keep selection and row-click behavior independent to avoid confusion</li>
+      <li>Do design responsive layouts that adapt to different screen sizes</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t embed heavily interactive components within grid cells</li>
+      <li>Don’t rely solely on color for status, use icons, labels or badges instead</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/grid/guide.md
+++ b/docs/components/grid/guide.md
@@ -47,7 +47,7 @@ Data grid columns, rows and cells have multiple states: Default, hover, active a
 
 ![Data grid states](https://www.figma.com/design/wEptRgAezDU1z80Cn3eZ0o/iX-Documentation-illustrations?node-id=7743-1852&t=pnIkODidZu9oNqXj-4)
 
-## Dos and Don'ts
+## Dos and Don’ts
 
 - Do only display primary information by default and use [column tool panels](https://www.ag-grid.com/javascript-data-grid/tool-panel-columns/) for secondary information
 - Do keep selection and row-click behavior independent to avoid confusion

--- a/docs/components/html-grid/guide.md
+++ b/docs/components/html-grid/guide.md
@@ -30,10 +30,20 @@ The HTML table is not a dedicated web component, but rather styling applied to t
 
 ## Dos and Don’ts
 
-- Do display only essential information
-- Do design tables to adapt responsively to different screen sizes, e.g. by hiding less critical columns on smaller screens, enabling horizontal scrolling or wrapping content within cells
-- Don’t use tables for unstructured or hierarchical data, use [event lists](../event-list) or [trees](../tree) instead
-- Don’t rely solely on color for status; also use icons or labels for additional transparency
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do display only essential information</li>
+      <li>Do design tables to adapt responsively to different screen sizes, e.g. by hiding less critical columns on smaller screens, enabling horizontal scrolling or wrapping content within cells</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use tables for unstructured or hierarchical data, use [event lists](../event-list) or [trees](../tree) instead</li>
+      <li>Don’t rely solely on color for status; also use icons or labels for additional transparency</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/html-grid/guide.md
+++ b/docs/components/html-grid/guide.md
@@ -28,7 +28,7 @@ The HTML table is not a dedicated web component, but rather styling applied to t
 - **Interaction**: By default, HTML tables do not include interactive features like sorting or selection. However, we can enhance tables with JavaScript to add sorting by clicking column headers and row selection via checkboxes. For more advanced interactions (e.g. filtering, grouping, inline editing), we recommend using [data grids](../grid) instead.
 - **Overflow**: By default, text wraps within cells. For tables with many columns, enable horizontal scrolling to maintain readability.
 
-## Dos and Don'ts
+## Dos and Don’ts
 
 - Do display only essential information
 - Do design tables to adapt responsively to different screen sizes, e.g. by hiding less critical columns on smaller screens, enabling horizontal scrolling or wrapping content within cells

--- a/docs/components/icon-button/guide.md
+++ b/docs/components/icon-button/guide.md
@@ -21,9 +21,19 @@ All the variants, options and states of the [button](../button) component apply 
 
 ## Dos and Don’ts
 
-- Do use icons that have a clear meaning for the user, otherwise use text buttons
-- Don’t use icon buttons in large numbers, instead use a toolbar
-- Don’t stretch icon buttons to span a container’s width
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use icons that have a clear meaning for the user, otherwise use text buttons</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use icon buttons in large numbers, instead use a toolbar</li>
+      <li>Don’t stretch icon buttons to span a container’s width</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/input-date-time/guide.mdx
+++ b/docs/components/input-date-time/guide.mdx
@@ -53,7 +53,7 @@ Date time input has five states: Default, hover, disabled, read-only and focused
 
 ![Date time input states](https://www.figma.com/design/wEptRgAezDU1z80Cn3eZ0o/iX-Documentation-illustrations?node-id=7441-86123&t=BStIEA03mmCLaHAL-4)
 
-## Dos and Don'ts
+## Dos and Don’ts
 
 <div class="dos-and-donts">
 <div class="dos">

--- a/docs/components/input-date-time/guide.mdx
+++ b/docs/components/input-date-time/guide.mdx
@@ -55,19 +55,19 @@ Date time input has five states: Default, hover, disabled, read-only and focused
 
 ## Dos and Don'ts
 
-<div class="dos-and-donts" markdown>
-<div class="dos" markdown>
-
-- Do use consistent date and time formats throughout the application to avoid confusion
-- Do provide clear instructions on the expected format, such as "Enter the date time in yyyy/mm/dd HH:mm format"
-- Do consider localization to adapt date and time formats to local conventions
-- Do use separate inputs for start and end date times when defining time ranges
-
+<div class="dos-and-donts">
+<div class="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do use consistent date and time formats throughout the application to avoid confusion</li>
+    <li>Do provide clear instructions on the expected format, such as "Enter the date time in yyyy/mm/dd HH:mm format"</li>
+    <li>Do consider localization to adapt date and time formats to local conventions</li>
+    <li>Do use separate inputs for start and end date times when defining time ranges</li>
+  </ul>
 </div>
-<div class="donts" markdown>
-
-- Don't use date time inputs when only a date or only a time is needed (use [date input](../input-date) or [time input](../input-time) instead)
-
+<div class="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don't use date time inputs when only a date or only a time is needed (use [date input](../input-date) or [time input](../input-time) instead)</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/input-date/guide.md
+++ b/docs/components/input-date/guide.md
@@ -55,12 +55,22 @@ Date input has five states: Default, hover, disabled, read-only and focused.
 
 ## Dos and Don’ts
 
-- Do use consistent date formats throughout the application to avoid confusion
-- Do use separate inputs for start and end dates to simplify date ranges
-- Do provide clear instructions, such as “Enter the date in yyyy/mm/dd format”
-- Do consider localization to adapt date formats to local conventions
-- Don’t use ambiguous formats like 09/08/2006 without giving clear context
-- Don’t allow free text without validation or formatting guidance
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use consistent date formats throughout the application to avoid confusion</li>
+      <li>Do use separate inputs for start and end dates to simplify date ranges</li>
+      <li>Do provide clear instructions, such as “Enter the date in yyyy/mm/dd format”</li>
+      <li>Do consider localization to adapt date formats to local conventions</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use ambiguous formats like 09/08/2006 without giving clear context</li>
+      <li>Don’t allow free text without validation or formatting guidance</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/input-number/guide.md
+++ b/docs/components/input-number/guide.md
@@ -45,10 +45,18 @@ The number input has five states: default, hover, focused, disabled and read-onl
 
 ## Dos and Don’ts
 
-- Do set appropriate min and max values to prevent invalid entries and guide user input
-- Do provide clear error messages when the input value is out of the allowed range or does not match the required pattern
-- Do consider special cases such as zero, negative numbers and very large numbers to ensure all possible inputs are handled correctly
-- Don’t specify patterns that do not align with your use case, e.g. inappropriate intervals between valid values
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do consider special cases such as zero, negative numbers and very large numbers to ensure all possible inputs are handled correctly</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t specify patterns that do not align with your use case, e.g. inappropriate intervals between valid values</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/input-time/guide.mdx
+++ b/docs/components/input-time/guide.mdx
@@ -33,6 +33,7 @@ Time inputs are typically used in forms, filters and scheduling tools to ensure 
   - **Header**: Hide the header when there is a label on the input, or if the context is conveyed in another way.
   - **Corners**
   - **Standalone appearance**
+
 ## Behavior in context
 
 - **Interaction**:
@@ -55,19 +56,19 @@ Time input has five states: Default, hover, disabled, read-only and focused.
 
 ## Dos and Don’ts
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Do use consistent time formats throughout the application to avoid confusion
-- Do add helper text to clarify the time format being used
-- Do ensure the time picker is accessible via keyboard
-- Do consider localization to adapt time formats to local conventions
-
+<div className="dos-and-donts">
+<div className="dos">
+<ul aria-label="Recommended practices">
+  <li>Do use consistent time formats throughout the application to avoid confusion</li>
+  <li>Do add helper text to clarify the time format being used</li>
+  <li>Do ensure the time picker is accessible via keyboard</li>
+  <li>Do consider localization to adapt time formats to local conventions</li>
+</ul>
 </div>
-<div className="donts" markdown="true">
-
-- Don’t use the same input for start and end times, instead separate them
-
+<div className="donts">
+<ul aria-label="Practices to avoid">
+  <li>Don’t use the same input for start and end times, instead separate them</li>
+</ul>
 </div>
 </div>
 

--- a/docs/components/input/guide.md
+++ b/docs/components/input/guide.md
@@ -43,11 +43,13 @@ The input field has five states: default, focused, hover, disabled and read-only
 
 ## Dos and Don’ts
 
-- Do use helper text to guide users through the input process
-- Do use feedback text to inform users about the status of their input
-- Do ensure that the width of the input field is appropriate for the expected content
-- Don’t overcrowd the input field with too many elements
-- Don’t use placeholders as a substitute for labels
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do ensure that the width of the input field is appropriate for the expected content</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/line-chart/overview.mdx
+++ b/docs/components/line-chart/overview.mdx
@@ -31,10 +31,20 @@ Advanced line charts are an enhanced version of basic line charts, designed to p
 
 ## Dos and Don’ts
 
-- Do start the Y-axis at zero and label axes clearly
-- Do use contrasting colors for multiple lines to better distinguish different data series
-- Do use consistent intervals on axes
-- Do highlight important data points
-- Do use visual cues to show gaps in data
-- Don’t overcrowd the chart with colors
-- Don’t clutter the chart with too many lines, we recommend no more than 7 lines
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do start the Y-axis at zero and label axes clearly</li>
+      <li>Do use contrasting colors for multiple lines to better distinguish different data series</li>
+      <li>Do use consistent intervals on axes</li>
+      <li>Do highlight important data points</li>
+      <li>Do use visual cues to show gaps in data</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t overcrowd the chart with colors</li>
+      <li>Don’t clutter the chart with too many lines, we recommend no more than 7 lines</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/link-button/guide.md
+++ b/docs/components/link-button/guide.md
@@ -41,6 +41,16 @@ Link buttons take five states: Default, hover, active, disabled and focused. On 
 
 ## Dos and Don’ts
 
-- Do use link buttons for navigation
-- Don’t use link buttons to indicate actions
-- Don’t place link buttons within a paragraph
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use link buttons for navigation</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use link buttons to indicate actions</li>
+      <li>Don’t place link buttons within a paragraph</li>
+    </ul>
+  </div>
+</div>

--- a/docs/components/loading-modal/guide.md
+++ b/docs/components/loading-modal/guide.md
@@ -30,18 +30,18 @@ Loading modals have two states: Closed and opened.
 
 ## Dos and Don’ts
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Do only use if any user interaction needs to be blocked, otherwise use [spinners](../spinner) instead
-- Do use if user interaction needs to be blocked and the progress is unknown, otherwise use [progress indicators](../progress-indicator) placed in [custom modals](../modal) instead
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do only use if any user interaction needs to be blocked, otherwise use [spinners](../spinner) instead</li>
+    <li>Do use if user interaction needs to be blocked and the progress is unknown, otherwise use [progress indicators](../progress-indicator) placed in [custom modals](../modal) instead</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Don’t block users for long tasks without an alternative
-- Don’t show vague messages that leave users unsure what is happening
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don’t block users for long tasks without an alternative</li>
+    <li>Don’t show vague messages that leave users unsure what is happening</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/message-modal/guide.md
+++ b/docs/components/message-modal/guide.md
@@ -56,19 +56,19 @@ Message modals have two states: Closed and opened.
 
 ## Dos and Don’ts
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Do use action labels that describe the result (avoid Yes or No)
-- Do communicate consequences clearly for destructive actions
-- Do keep messages short and scannable
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do use action labels that describe the result (avoid Yes or No)</li>
+    <li>Do communicate consequences clearly for destructive actions</li>
+    <li>Do keep messages short and scannable</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Don’t use message modals for non-essential information, use [toasts](../toast) instead
-- Don’t hide confirm actions behind ambiguous labels
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don’t use message modals for non-essential information, use [toasts](../toast) instead</li>
+    <li>Don’t hide confirm actions behind ambiguous labels</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/modal/guide.md
+++ b/docs/components/modal/guide.md
@@ -6,7 +6,7 @@ doc-type: 'tab-item'
 
 Custom modals present rich, contextual content, e.g. forms, complex workflows or nested interactions that require the user's focus.
 
-Use custom models when a task requires immediate attention and the user returns to the same place after closing the modal.
+Use custom modals when a task requires immediate attention and the user returns to the same place after closing the modal.
 
 ![Modal overview](https://www.figma.com/design/wEptRgAezDU1z80Cn3eZ0o/iX-Documentation-illustrations?node-id=7350-2529&t=WHbXyipgpGwQbVsV-4)
 

--- a/docs/components/modal/guide.md
+++ b/docs/components/modal/guide.md
@@ -58,23 +58,23 @@ Modals have two states: Closed and opened.
 
 ## Dos and Don’ts
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Do provide at least one visible way to close the modal
-- Do provide a clear primary action that describes the result
-- Do ensure all controls are accessible by keyboard and screen‑reader
-- Do preserve scroll position and page state when closing
-- Do return users to the previous state when cancelling, not an unrelated page
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do provide at least one visible way to close the modal</li>
+    <li>Do provide a clear primary action that describes the result</li>
+    <li>Do ensure all controls are accessible by keyboard and screen‑reader</li>
+    <li>Do preserve scroll position and page state when closing</li>
+    <li>Do return users to the previous state when cancelling, not an unrelated page</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Don’t use modals if a decision should be made (use [message modals](../message-modal) instead)
-- Don’t nest modals, e.g. to load more data, instead use [spinners](../spinner) within modal contents)
-- Don’t auto close modals for irreversible actions
-- Don’t overload the modal with unrelated content
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don’t use modals if a decision should be made (use [message modals](../message-modal) instead)</li>
+    <li>Don’t nest modals, e.g. to load more data, instead use [spinners](../spinner) within modal contents)</li>
+    <li>Don’t auto close modals for irreversible actions</li>
+    <li>Don’t overload the modal with unrelated content</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/panes/guide.md
+++ b/docs/components/panes/guide.md
@@ -52,11 +52,21 @@ Panes have two states: collapsed and expanded. The appearance of the states vari
 
 ## Dos and Don’ts
 
-- Do use panes to organize your content and guide your users' attention
-- Do use panes to display different views within a single screen
-- Do use panes to expand/collapse content or hide/reveal content
-- Don’t use panes for a small amount of content
-- Don’t use panes for content that should stay visible
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use panes to organize your content and guide your users' attention</li>
+      <li>Do use panes to display different views within a single screen</li>
+      <li>Do use panes to expand/collapse content or hide/reveal content</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use panes for a small amount of content</li>
+      <li>Don’t use panes for content that should stay visible</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/pill/guide.md
+++ b/docs/components/pill/guide.md
@@ -45,11 +45,21 @@ Pills are read-only.
 
 ## Dos and Don’ts
 
-- Do use pills to communicate tags and categories
-- Do use pills to indicate the status or characteristics of an item
-- Don’t overuse pills as this leads to cluttered and overwhelming interfaces
-- Don’t use different styles for pills with the same or similar use
-- Don’t use pills if users can interact with the component (e.g. click, close) use chips instead
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use pills to communicate tags and categories</li>
+      <li>Do use pills to indicate the status or characteristics of an item</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t overuse pills as this leads to cluttered and overwhelming interfaces</li>
+      <li>Don’t use different styles for pills with the same or similar use</li>
+      <li>Don’t use pills if users can interact with the component (e.g. click, close) use chips instead</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/popover-news/guide.md
+++ b/docs/components/popover-news/guide.md
@@ -26,9 +26,13 @@ Unlike a modal, popover news does not prevent users from navigating and interact
 
 ## Dos and Don’ts
 
-- Do use popover news for "nice to know" information
-- Don‘t use popover news for essential information a user must read, instead use a [modal](../messagebar)
-- Don‘t use popover news for system feedback or messages, instead use a [modal](../toast)
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use popover news for "nice to know" information</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/progress-indicator/guide.md
+++ b/docs/components/progress-indicator/guide.md
@@ -53,20 +53,20 @@ For more information about writing effective helper texts or labels, see our [UX
 
 ## Dos and Don’ts
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Do use progress indicators consistently for similar processes
-- Do use progress indicators for determinate processes where progress can be measured (otherwise use [spinners](../spinner/index.mdx))
-- Do use linear progress indicators in horizontal layouts and circular indicators in compact spaces or centered layouts
-- Do keep your slot content short, especially for the centered alignment (use helper texts and labels for lengthier content)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do use progress indicators consistently for similar processes</li>
+    <li>Do use progress indicators for determinate processes where progress can be measured (otherwise use [spinners](../spinner/index.mdx))</li>
+    <li>Do use linear progress indicators in horizontal layouts and circular indicators in compact spaces or centered layouts</li>
+    <li>Do keep your slot content short, especially for the centered alignment (use helper texts and labels for lengthier content)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Don't use progress indicators for operations shorter than one second
-- Don't only indicate progress completion with the indicator without clear task messages, e.g. success toasts or displaying the loaded content
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don't use progress indicators for operations shorter than one second</li>
+    <li>Don't only indicate progress completion with the indicator without clear task messages, e.g. success toasts or displaying the loaded content</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/radio/guide.md
+++ b/docs/components/radio/guide.md
@@ -33,11 +33,21 @@ Radio buttons are presented in groups to signify that only one selection is allo
 
 ## Dos and Don’ts
 
-- Do use radio buttons when the user needs to select only one option from a set of options
-- Do group related radio buttons together to indicate that only one option can be selected at a time
-- Do provide a default (already selected) option when the user first sees the radio button group
-- Don’t use radio buttons if the user needs to select multiple options from a set of options - use a checkbox instead
-- Don’t use only one radio button in a group, groups should have at least two options
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use radio buttons when the user needs to select only one option from a set of options</li>
+      <li>Do group related radio buttons together to indicate that only one option can be selected at a time</li>
+      <li>Do provide a default (already selected) option when the user first sees the radio button group</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use radio buttons if the user needs to select multiple options from a set of options - use a checkbox instead</li>
+      <li>Don’t use only one radio button in a group, groups should have at least two options</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/range-field/guide.md
+++ b/docs/components/range-field/guide.md
@@ -42,13 +42,23 @@ Range fields rely on the states of the paired inputs. Use the same guidance as [
 
 ## Dos and Don’ts
 
-- Do use range fields when start and end values describe one bounded interval
-- Do label both inputs clearly so users can scan the order quickly
-- Do omit labels on both inputs consistently when the surrounding context already makes the range clear
-- Do validate that the end value is not smaller or earlier than the start value
-- Don’t use range fields for single values or unrelated inputs
-- Don’t use different input types, formats or levels of precision within one range
-- Don’t mix date, time and date-time inputs in one range
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use range fields when start and end values describe one bounded interval</li>
+      <li>Do label both inputs clearly so users can scan the order quickly</li>
+      <li>Do omit labels on both inputs consistently when the surrounding context already makes the range clear</li>
+      <li>Do validate that the end value is not smaller or earlier than the start value</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use range fields for single values or unrelated inputs</li>
+      <li>Don’t use different input types, formats or levels of precision within one range</li>
+      <li>Don’t mix date, time and date-time inputs in one range</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/select/guide.md
+++ b/docs/components/select/guide.md
@@ -59,12 +59,22 @@ The select field has five states: default, hover, focused, disabled and read-onl
 
 ## Dos and Don’ts
 
-- Do consider performance when loading an extensive list of items
-- Do use the select component when there is a finite list of items available to avoid manual input errors or duplicates
-- Do sort items logically, e.g. alphabetically or numerically
-- Don’t use selects for binary choices, like yes and no, use [radio buttons](../toggle) instead
-- Don’t use selects for navigational or search patterns, use [category filters](../expanding-search) instead
-- Don’t combine several data attributes in an item label, use [HTML tables](../html-grid) or [AG Grids](../grid) with a search functionality instead
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do consider performance when loading an extensive list of items</li>
+      <li>Do use the select component when there is a finite list of items available to avoid manual input errors or duplicates</li>
+      <li>Do sort items logically, e.g. alphabetically or numerically</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use selects for binary choices, like yes and no, use [radio buttons](../toggle) instead</li>
+      <li>Don’t use selects for navigational or search patterns, use [category filters](../expanding-search) instead</li>
+      <li>Don’t combine several data attributes in an item label, use [HTML tables](../html-grid) or [AG Grids](../grid) with a search functionality instead</li>
+    </ul>
+  </div>
+</div>
 
 ![Don’t combine data attributes](https://www.figma.com/design/wEptRgAezDU1z80Cn3eZ0o/iX-Pattern-Illustrations?node-id=3978-800&t=MWpyPDZDK5B531n9-4)
 

--- a/docs/components/select/guide.md
+++ b/docs/components/select/guide.md
@@ -70,7 +70,7 @@ The select field has five states: default, hover, focused, disabled and read-onl
   </div>
   <div class="donts">
     <ul aria-label="Practices to avoid">
-      <li>Don’t use selects for binary choices, like yes and no, use [radio buttons](../toggle) instead</li>
+      <li>Don’t use selects for binary choices, like yes and no, use [radio buttons](../radio) instead</li>
       <li>Don’t use selects for navigational or search patterns, use [category filters](../expanding-search) instead</li>
       <li>Don’t combine several data attributes in an item label, use [HTML tables](../html-grid) or [AG Grids](../grid) with a search functionality instead</li>
     </ul>
@@ -87,5 +87,4 @@ The select field has five states: default, hover, focused, disabled and read-onl
 - [Input](../input)
 - [Radio button](../radio)
 - [Checkbox](../checkbox)
-- [Toggle](../toggle)
 - [Date input](../input-date)

--- a/docs/components/split-button/guide.md
+++ b/docs/components/split-button/guide.md
@@ -33,9 +33,19 @@ Split buttons have five states: Default, hover, active, disabled and focused. St
 
 ## Dos and Don’ts
 
-- Do use split buttons when there is a frequent or most-important action
-- Don’t use split buttons for unrelated actions
-- Don’t duplicate the default option in the dropdown
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use split buttons when there is a frequent or most-important action</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use split buttons for unrelated actions</li>
+      <li>Don’t duplicate the default option in the dropdown</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/textarea/guide.md
+++ b/docs/components/textarea/guide.md
@@ -54,10 +54,20 @@ Textareas have five states: Default, hover, focused, read-only and disabled.
 
 ## Dos and Don’ts
 
-- Do ensure the textarea size matches the expected input, e.g. 5 to 10 rows for detailed feedback
-- Do use the placeholder to give users an example of the expected input
-- Do set minimum and maximum character limits to ensure appropriate input length
-- Don’t use the textarea for short, single-line input like name or email address, use an [input field](../input) instead
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do ensure the textarea size matches the expected input, e.g. 5 to 10 rows for detailed feedback</li>
+      <li>Do use the placeholder to give users an example of the expected input</li>
+      <li>Do set minimum and maximum character limits to ensure appropriate input length</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use the textarea for short, single-line input like name or email address, use an [input field](../input) instead</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/time-picker/guide.mdx
+++ b/docs/components/time-picker/guide.mdx
@@ -40,18 +40,18 @@ An individual time item of a time picker has five states: Default, hover, active
 
 ## Dos and Don’ts
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Do use the time picker to ensure accurate time selection (we recommend to use [time inputs](../input-time) for that reason)
-- Do provide clear instructions and labels for users
-- Do ensure the time picker is accessible via keyboard
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Do use the time picker to ensure accurate time selection (we recommend to use [time inputs](../input-time) for that reason)</li>
+    <li>Do provide clear instructions and labels for users</li>
+    <li>Do ensure the time picker is accessible via keyboard</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Don’t clutter the time picker with unnecessary options
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don’t clutter the time picker with unnecessary options</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/components/toast/guide.md
+++ b/docs/components/toast/guide.md
@@ -42,12 +42,22 @@ Toasts are UI elements where an event causes a small text field to appear on scr
 
 ## Dos and Don’ts
 
-- Do use toasts to provide contextual tips and shortcuts for users
-- Do use toasts to instantly inform a user about the outcome of an action
-- Do include shortcuts to undo an action immediately after it’s taken
-- Do stick with a consistent position for toasts within the same app and avoid interchanging their positions
-- Don’t use toasts for high-priority or critical alerts that prevent the user from continuing their work (use a [modal](../messagebar) instead)
-- Don’t edit or reuse icons or icon colors from the four predefined toast types when creating custom toasts
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use toasts to provide contextual tips and shortcuts for users</li>
+      <li>Do use toasts to instantly inform a user about the outcome of an action</li>
+      <li>Do include shortcuts to undo an action immediately after it’s taken</li>
+      <li>Do stick with a consistent position for toasts within the same app and avoid interchanging their positions</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use toasts for high-priority or critical alerts that prevent the user from continuing their work (use a [modal](../messagebar) instead)</li>
+      <li>Don’t edit or reuse icons or icon colors from the four predefined toast types when creating custom toasts</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/toggle-button/guide.md
+++ b/docs/components/toggle-button/guide.md
@@ -27,9 +27,19 @@ Toggle buttons have five states: Default, hover, active, disabled, loading and f
 
 ## Dos and Don’ts
 
-- Do use toggle buttons when users can switch a setting on or off independently
-- Do use toggle buttons when two opposing options don’t follow the on/off metaphor
-- Don’t use toggle buttons in button groups where only one option can be selected (use normal [buttons](../button/index.mdx) or [icon buttons](../icon-button/index.mdx) instead)
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use toggle buttons when users can switch a setting on or off independently</li>
+      <li>Do use toggle buttons when two opposing options don’t follow the on/off metaphor</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use toggle buttons in button groups where only one option can be selected (use normal [buttons](../button/index.mdx) or [icon buttons](../icon-button/index.mdx) instead)</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/components/toggle/guide.md
+++ b/docs/components/toggle/guide.md
@@ -32,12 +32,22 @@ A toggle is a user interface element that enables users to switch between two st
 
 ## Dos and Don’ts
 
-- Do use toggles for single features or options that need to be switched quickly and easily
-- Do provide clear labels for toggles to indicate what they control
-- Do use toggles consistently throughout the interface for similar actions or settings
-- Don’t use toggles for complex multi-state options or settings
-- Don’t use toggles for actions that require a confirmation or additional input
-- Don’t use toggles for actions that are irreversible or have serious consequences
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use toggles for single features or options that need to be switched quickly and easily</li>
+      <li>Do provide clear labels for toggles to indicate what they control</li>
+      <li>Do use toggles consistently throughout the interface for similar actions or settings</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use toggles for complex multi-state options or settings</li>
+      <li>Don’t use toggles for actions that require a confirmation or additional input</li>
+      <li>Don’t use toggles for actions that are irreversible or have serious consequences</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/conversational-design/designing-conversations/acknowledging-users.md
+++ b/docs/guidelines/conversational-design/designing-conversations/acknowledging-users.md
@@ -27,7 +27,17 @@ Here, although there may be some lag time between the query and the response, th
 
 ## Dos and Don’ts
 
-- Do use discourse markers to acknowledge users (see grammar section)  
--	Do use interim acknowledgments if the query response takes time to load  
--	Do read out dialogs to test if any acknowledgments are naturally missing  
--	Don’t forget to balance efficiency with authenticity 
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use discourse markers to acknowledge users (see grammar section)</li>
+      <li>Do use interim acknowledgments if the query response takes time to load</li>
+      <li>Do read out dialogs to test if any acknowledgments are naturally missing</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t forget to balance efficiency with authenticity</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/designing-conversations/ad-hoc-conversations.md
+++ b/docs/guidelines/conversational-design/designing-conversations/ad-hoc-conversations.md
@@ -30,8 +30,18 @@ Finally, in the face of truly unprofessional and offensive input, the following 
 **Copilot:** As an AI language model, I don’t have personal opinions or feelings, but I am designed to follow ethical guidelines. I **do not** engage in discussions or create content that promotes racism, sexism, or any form of discrimination. If you encounter any inappropriate responses, please let me know, and I'll do my best to address them.
 ## Dos and Don’ts
 
-- Do consider training your chatbot to filter for a list of offensive terms
--	Do consider localization and cultural nuances, such as “master” and “slave”
--	Do train your chatbot to move users back on track
--	Don’t forget to test and train for offensive user input
--	Don’t forget to allow for some harmless non-work interactions
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do consider training your chatbot to filter for a list of offensive terms</li>
+      <li>Do consider localization and cultural nuances, such as “master” and “slave”</li>
+      <li>Do train your chatbot to move users back on track</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t forget to test and train for offensive user input</li>
+      <li>Don’t forget to allow for some harmless non-work interactions</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/designing-conversations/confirming-request.md
+++ b/docs/guidelines/conversational-design/designing-conversations/confirming-request.md
@@ -23,7 +23,17 @@ In this interaction we see a simple request for confirmation before completing t
 
 ## Dos and Don’ts
 
--	Do make all confirmations clear and transparent before processing tasks  
--	Do mitigate risks associated with making changes to systems or processes  
--	Do add warnings and consequences for significant or hazardous changes  
--	Don’t ask for confirmation more than once 
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do make all confirmations clear and transparent before processing tasks</li>
+      <li>Do mitigate risks associated with making changes to systems or processes</li>
+      <li>Do add warnings and consequences for significant or hazardous changes</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t ask for confirmation more than once</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/designing-conversations/ending-conversations.md
+++ b/docs/guidelines/conversational-design/designing-conversations/ending-conversations.md
@@ -27,7 +27,17 @@ Here the chatbot offers an apology for not being able to support the user, expla
 
 ## Dos and Don’ts
 
-- Do consider adding a time-out feature   
-- Do consider adding thumbs up and thumbs down icons to get feedback   
-- Don’t loop back and have the chatbot reintroduce themselves
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do consider adding a time-out feature</li>
+      <li>Do consider adding thumbs up and thumbs down icons to get feedback</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t loop back and have the chatbot reintroduce themselves</li>
+    </ul>
+  </div>
+</div>
  

--- a/docs/guidelines/conversational-design/designing-conversations/funneling-input.md
+++ b/docs/guidelines/conversational-design/designing-conversations/funneling-input.md
@@ -33,6 +33,16 @@ Presenting options or choices for the user to select from also helps to funnel q
 
 ## Dos and Don’ts
 
--	Do train your chatbot to guide users to their point  
--	Do test your chatbot with vague queries   
--	Don’t assume users know what to ask for 
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do train your chatbot to guide users to their point</li>
+      <li>Do test your chatbot with vague queries</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t assume users know what to ask for</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/designing-conversations/greeting-users.md
+++ b/docs/guidelines/conversational-design/designing-conversations/greeting-users.md
@@ -31,7 +31,17 @@ This chatbot is less formal, more conversational and would be found within more 
 
 ## Dos and Don’ts
 
-- Do keep your greeting short and simple  
--	Do check every word matches your brand  
--	Don’t add a list of bullet points explaining what the chatbot can do   
--	Don’t use slang or idiomatic language in your greeting 
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do keep your greeting short and simple</li>
+      <li>Do check every word matches your brand</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t add a list of bullet points explaining what the chatbot can do</li>
+      <li>Don’t use slang or idiomatic language in your greeting</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/designing-conversations/handing-off-users.md
+++ b/docs/guidelines/conversational-design/designing-conversations/handing-off-users.md
@@ -19,6 +19,16 @@ Here the chatbot is polite, professional and after a couple of clarifying questi
 
 ## Dos and Don’ts
 
-- Do ensure support features are current and live   
-- Do be transparent when your chatbot is handing users over    
--	Don’t try more than 3 times to ask for clarification; know when to hand off 
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do ensure support features are current and live</li>
+      <li>Do be transparent when your chatbot is handing users over</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t try more than 3 times to ask for clarification; know when to hand off</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/designing-conversations/handling-errors.md
+++ b/docs/guidelines/conversational-design/designing-conversations/handling-errors.md
@@ -22,7 +22,17 @@ Here the chatbot is immediately apologetic and tells the user they cannot comple
 Here, although it’s clear what the user wants, they can’t give the chatbot the information it needs to fulfill the request. In this situation, the chatbot immediately says they cannot carry out the task, explains why, and then tells the user where to find a solution. We recommend this three-step approach for chatbot responses and for error messages in general.   
 ## Dos and Don’ts
 
-- Do assume your chatbot makes mistakes  
-- Do try to ‘break’ your chatbot in testing   
-- Do train your chatbot to tell users immediately if they cannot complete a task     
-- Don’t forget to add a disclaimer stating that information could be incorrect
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do assume your chatbot makes mistakes</li>
+      <li>Do try to ‘break’ your chatbot in testing</li>
+      <li>Do train your chatbot to tell users immediately if they cannot complete a task</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t forget to add a disclaimer stating that information could be incorrect</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/designing-conversations/overview.md
+++ b/docs/guidelines/conversational-design/designing-conversations/overview.md
@@ -34,9 +34,19 @@ Use your dialogs to highlight the complex interactions required for your industr
 4.	You have your own brand voice and tone guidelines
 ## Dos and Don’ts
 
-- Do create example conversations based on user personas
-- Do focus on industrial-relevant communicative functions
-- Do offer users an exit or calls to action to support further actions
-- Don’t forget to read aloud your dialogs; if it sounds robotic, it is robotic
-- Don’t create lengthy monologues, instead keep responses concise and simple
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do create example conversations based on user personas</li>
+      <li>Do focus on industrial-relevant communicative functions</li>
+      <li>Do offer users an exit or calls to action to support further actions</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t forget to read aloud your dialogs; if it sounds robotic, it is robotic</li>
+      <li>Don’t create lengthy monologues, instead keep responses concise and simple</li>
+    </ul>
+  </div>
+</div>
 

--- a/docs/guidelines/conversational-design/designing-conversations/troubleshooting.md
+++ b/docs/guidelines/conversational-design/designing-conversations/troubleshooting.md
@@ -22,7 +22,18 @@ Here the chatbot says exactly what the problem is, but this response lacks empat
 Here the chatbot says exactly what the problem is, gives a possible reason for the lack of connection and then provides a solution to move the user forward.
 
 ## Dos and Don’ts
-- Do provide calls to action when troubleshooting
-- Do offer step by step solutions using technical documentation
-- Don’t allow your chatbot to offer competitor solutions to their problems
-- Don’t allow your chatbot to hallucinate (make up) solutions without concrete resources
+
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do provide calls to action when troubleshooting</li>
+      <li>Do offer step by step solutions using technical documentation</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don't allow your chatbot to offer competitor solutions to their problems</li>
+      <li>Don't allow your chatbot to hallucinate (make up) solutions without concrete resources</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/essentials/system-presonas.md
+++ b/docs/guidelines/conversational-design/essentials/system-presonas.md
@@ -163,13 +163,23 @@ There are two persona templates: a basic set of prompts and an exhaustive set of
 
 ## Dos and Don’ts
 
-- Do test and retest your chatbot to ensure its responses are in line with your brand
-- Do predefine responses with persona prompts to avoid generic responses
-- Do create different personas if the bot needs to work with multiple, varied users
-- Do base system personas on user research to ensure there is a good level of customer understanding
-- Don’t pretend your chatbot is human – it should be clear to your users that they’re talking to a chatbot
-- Don’t encourage your chatbot to engage in unnecessary small talk with your users
-- Don’t use more than a page of persona prompts – only take what’s vital and relevant from our templates
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do test and retest your chatbot to ensure its responses are in line with your brand</li>
+      <li>Do predefine responses with persona prompts to avoid generic responses</li>
+      <li>Do create different personas if the bot needs to work with multiple, varied users</li>
+      <li>Do base system personas on user research to ensure there is a good level of customer understanding</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t pretend your chatbot is human – it should be clear to your users that they’re talking to a chatbot</li>
+      <li>Don’t encourage your chatbot to engage in unnecessary small talk with your users</li>
+      <li>Don’t use more than a page of persona prompts – only take what’s vital and relevant from our templates</li>
+    </ul>
+  </div>
+</div>
 
 
 

--- a/docs/guidelines/conversational-design/essentials/user-intent.md
+++ b/docs/guidelines/conversational-design/essentials/user-intent.md
@@ -45,8 +45,18 @@ Here we see that although the intent for maintenance is very explicit, the chatb
 
 ## Dos and Don’ts
 
-- Do carry out extensive research on user needs and goals
-- Do work with your teams to establish and predict user intent with example dialogs
-- Do test your chatbot with explicit and implicit requests to assess evaluation of user intent
-- Don’t assume your users will be explicit about what they need
-- Don’t assume users are skilled at prompting your chatbot
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do carry out extensive research on user needs and goals</li>
+      <li>Do work with your teams to establish and predict user intent with example dialogs</li>
+      <li>Do test your chatbot with explicit and implicit requests to assess evaluation of user intent</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t assume your users will be explicit about what they need</li>
+      <li>Don’t assume users are skilled at prompting your chatbot</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/essentials/wording-terms.mdx
+++ b/docs/guidelines/conversational-design/essentials/wording-terms.mdx
@@ -329,7 +329,17 @@ Avoid technical, robotic phrases like “Please stand by…” as these are outd
 
 ## Dos and Don’ts
 
-- Do use sentence casing to align with our UX writing guidelines
-- Do ensure the voice and tone aligns with your product and our iX conversational design principles
-- Don’t use synonyms to vary the UI wording, be consistent and use the same words repeatedly
-- Don’t use “Creating…” as the progress indicator as there is no creative process and is misleading
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use sentence casing to align with our UX writing guidelines</li>
+      <li>Do ensure the voice and tone aligns with your product and our iX conversational design principles</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use synonyms to vary the UI wording, be consistent and use the same words repeatedly</li>
+      <li>Don’t use “Creating…” as the progress indicator as there is no creative process and is misleading</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/essentials/wording-terms.mdx
+++ b/docs/guidelines/conversational-design/essentials/wording-terms.mdx
@@ -327,7 +327,7 @@ Avoid technical, robotic phrases like “Please stand by…” as these are outd
 </div>
 </div>
 
-## Dos and Don’ts 
+## Dos and Don’ts
 
 - Do use sentence casing to align with our UX writing guidelines
 - Do ensure the voice and tone aligns with your product and our iX conversational design principles

--- a/docs/guidelines/conversational-design/essentials/wording-terms.mdx
+++ b/docs/guidelines/conversational-design/essentials/wording-terms.mdx
@@ -33,13 +33,13 @@ Use any of the five messages depending on your product and use case.
 - **With username:** Hello Felix, how can I help you today?
 - **With product and username:** Hello Sara, I'm  [Copilot name]. How can I help you today?
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Well, hello! I’m your friendly chatbot.
-- Welcome to chatbot. State your issue now.
-- What do you want?
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Well, hello! I’m your friendly chatbot.</li>
+    <li>Welcome to chatbot. State your issue now.</li>
+    <li>What do you want?</li>
+  </ul>
 </div>
 </div>
 
@@ -47,32 +47,32 @@ Use any of the five messages depending on your product and use case.
 
 Use these universal, non-specific options to encourage solution and technology-focused input. Avoid generic, open placeholders that encourage off-topic queries.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Enter your query here…
-- Enter a command, question or topic…
-- Enter a command, question or topic to begin…
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Enter your query here…</li>
+    <li>Enter a command, question or topic…</li>
+    <li>Enter a command, question or topic to begin…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Ask me anything…
-- Start typing…
-- What’s on your mind?
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Ask me anything…</li>
+    <li>Start typing…</li>
+    <li>What’s on your mind?</li>
+  </ul>
 </div>
 </div>
 
 Use alternative placeholder text when your chatbot has a single use case.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Search technical documentation…
-- Enter error code…
-- Search parts catalog…
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Search technical documentation…</li>
+    <li>Enter error code…</li>
+    <li>Search parts catalog…</li>
+  </ul>
 </div>
 </div>
 
@@ -80,34 +80,34 @@ Use alternative placeholder text when your chatbot has a single use case.
 
 Always use “generate” as the main progress indicator verb with ellipses (...).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Generating…
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Generating…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Generating response
-- Creating response…
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Generating response</li>
+    <li>Creating response…</li>
+  </ul>
 </div>
 </div>
 
 Use “generate” to match the action verb to stop the chatbot responding or ask the chatbot to continue responding without ellipses.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Stop generating
-- Continue generating
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Stop generating</li>
+    <li>Continue generating</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Stop generating…
-- Continue generating…
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Stop generating…</li>
+    <li>Continue generating…</li>
+  </ul>
 </div>
 </div>
 
@@ -115,27 +115,27 @@ Use “generate” to match the action verb to stop the chatbot responding or as
 
 Use a tooltip on hover to clarify any recording limitations and tell users how to stop recording.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Click to start and stop voice recording.
-- Click to start and stop voice recording (max 2 minutes).
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Click to start and stop voice recording.</li>
+    <li>Click to start and stop voice recording (max 2 minutes).</li>
+  </ul>
 </div>
 </div>
 
 Use “Recording…” as feedback to show the feature is working.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Recording…
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Recording…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- I’m listening…
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>I’m listening…</li>
+  </ul>
 </div>
 </div>
 
@@ -143,18 +143,18 @@ Use “Recording…” as feedback to show the feature is working.
 
 Use thumbs up and down icons to request feedback.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Thumbs up icon (<IxIcon name={iconThumbUp} size="16"></IxIcon>)
-- Thumbs down icon (<IxIcon name={iconThumbDown} size="16"></IxIcon>)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Thumbs up icon (<IxIcon name={iconThumbUp} size="16"></IxIcon>)</li>
+    <li>Thumbs down icon (<IxIcon name={iconThumbDown} size="16"></IxIcon>)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Helpful
-- Not helpful
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Helpful</li>
+    <li>Not helpful</li>
+  </ul>
 </div>
 </div>
 
@@ -162,21 +162,21 @@ Use thumbs up and down icons to request feedback.
 
 Use “last” instead of “previous” and “prior” for time-related terminology in chat history.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Today
-- Yesterday
-- Last 7 days
-- Last 30 days
-- Older
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Today</li>
+    <li>Yesterday</li>
+    <li>Last 7 days</li>
+    <li>Last 30 days</li>
+    <li>Older</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Previous 7 days
-- Prior week
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Previous 7 days</li>
+    <li>Prior week</li>
+  </ul>
 </div>
 </div>
 
@@ -192,33 +192,33 @@ Use “last” instead of “previous” and “prior” for time-related termin
 
 Use the following action wording for consistency within all our chatbots.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- New chat
-- Send
-- Generate new prompts
-- Refresh prompts
-- Show more prompts
-- Attach files
-- Upload files
-- Share
-- Copy
-- Expand
-- Collapse
-- Maximize chat window
-- Minimize chat window
-- Close chat window
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>New chat</li>
+    <li>Send</li>
+    <li>Generate new prompts</li>
+    <li>Refresh prompts</li>
+    <li>Show more prompts</li>
+    <li>Attach files</li>
+    <li>Upload files</li>
+    <li>Share</li>
+    <li>Copy</li>
+    <li>Expand</li>
+    <li>Collapse</li>
+    <li>Maximize chat window</li>
+    <li>Minimize chat window</li>
+    <li>Close chat window</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Clear chat
-- Submit
-- Give me another
-- Show me others
-- Import files
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Clear chat</li>
+    <li>Submit</li>
+    <li>Give me another</li>
+    <li>Show me others</li>
+    <li>Import files</li>
+  </ul>
 </div>
 </div>
 
@@ -239,17 +239,17 @@ Book webinar
 
 Use “sources” as the text label to indicate where the generated information is from.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Sources
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Sources</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Resources
-- Sources and references
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Resources</li>
+    <li>Sources and references</li>
+  </ul>
 </div>
 </div>
 
@@ -259,12 +259,12 @@ Avoid mixing terms (resources, sources) and instead label the source format, e.g
 
 Use clear wording to differentiate between multiple bots when displaying output.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Responses generated by agent X
-- Responses generated by: agent X (with agent selection dropdown)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Responses generated by agent X</li>
+    <li>Responses generated by: agent X (with agent selection dropdown)</li>
+  </ul>
 </div>
 </div>
 
@@ -272,19 +272,19 @@ Use clear wording to differentiate between multiple bots when displaying output.
 
 Avoid punctuation, such as exclamation marks for buttons, hover text, titles and tags.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Show more
-- Send
-- Stop
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Show more</li>
+    <li>Send</li>
+    <li>Stop</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Show more!
-- Send?
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Show more!</li>
+    <li>Send?</li>
+  </ul>
 </div>
 </div>
 
@@ -294,36 +294,36 @@ Most problematic wording involves the bot expressing itself as a human with huma
 
 Use “generating” not “thinking” as chatbots don’t perform cognitive processes.
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Thinking…
-- Thinking about the best response…
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Thinking…</li>
+    <li>Thinking about the best response…</li>
+  </ul>
 </div>
 </div>
 
 Avoid prompting emotional language like “I’m afraid…” in industrial chatbots.
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- I’m afraid that I can’t help you right now as I’m assessing the data.
-- I understand what you mean.
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>I’m afraid that I can’t help you right now as I’m assessing the data.</li>
+    <li>I understand what you mean.</li>
+  </ul>
 </div>
 </div>
 
 Avoid technical, robotic phrases like “Please stand by…” as these are outdated, passive and unhelpful.
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Please stand by while I process your request.
-- Please wait while I prepare a response.
-- Please be patient.
-- Bear with me.
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Please stand by while I process your request.</li>
+    <li>Please wait while I prepare a response.</li>
+    <li>Please be patient.</li>
+    <li>Bear with me.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/conversational-design/language.md
+++ b/docs/guidelines/conversational-design/language.md
@@ -110,7 +110,17 @@ Here the response is more concise, professional and shows the chatbot is aware o
 
 ## Dos and Don’ts
 
-- Do use your brand’s voice rules to shape your chatbot voice
-- Do work with developers to support data set collection
-- Don’t assume your users write correctly or accurately
-- Don’t forget to implement new NLP models as they advance
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use your brand’s voice rules to shape your chatbot voice</li>
+      <li>Do work with developers to support data set collection</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t assume your users write correctly or accurately</li>
+      <li>Don’t forget to implement new NLP models as they advance</li>
+    </ul>
+  </div>
+</div>

--- a/docs/guidelines/conversational-design/resources/chatbot-checklist.md
+++ b/docs/guidelines/conversational-design/resources/chatbot-checklist.md
@@ -55,12 +55,23 @@ Follow these steps and answer the questions with your teams to create your indus
    - How do we assess the chatbot's performance? Consider response time, accuracy, successful/abandoned interactions.
 
 ## Dos and Don’ts
-- Do work with all stakeholders to ensure transparency
-- Do customize chatbot responses for project-specific terminology and processes
-- Do consider how your chatbot hands off to humans for complex issues
-- Do read and review interactions (with user consent)
-- Don’t assume all chatbot interactions are successful
-- Don’t forget to retrain, test and update your chatbot
+
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do work with all stakeholders to ensure transparency</li>
+      <li>Do customize chatbot responses for project-specific terminology and processes</li>
+      <li>Do consider how your chatbot hands off to humans for complex issues</li>
+      <li>Do read and review interactions (with user consent)</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don't assume all chatbot interactions are successful</li>
+      <li>Don't forget to retrain, test and update your chatbot</li>
+    </ul>
+  </div>
+</div>
 
 
 

--- a/docs/guidelines/language/basics.md
+++ b/docs/guidelines/language/basics.md
@@ -36,24 +36,24 @@ description: "Dive into the fundamental principles of UX writing, where you'll l
 
 - Avoid using negative contractions as they can appear too informal
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- their, them, theirs, salesperson
-- Welcome to this application
-- X appears when detail view has selected events
-- cannot, will not
-- you’ll, we’ve
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>their, them, theirs, salesperson</li>
+    <li>Welcome to this application</li>
+    <li>X appears when detail view has selected events</li>
+    <li>cannot, will not</li>
+    <li>you’ll, we’ve</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- his, hers, him, salesman
-- Hey there!
-- X doesn’t appear if detail view has no selected events
-- can’t, won’t
-- you will, we have
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>his, hers, him, salesman</li>
+    <li>Hey there!</li>
+    <li>X doesn’t appear if detail view has no selected events</li>
+    <li>can’t, won’t</li>
+    <li>you will, we have</li>
+  </ul>
 </div>
 </div>
 
@@ -79,58 +79,58 @@ description: "Dive into the fundamental principles of UX writing, where you'll l
 
 - Capitalize named app functions and UI elements: Go to Settings, Allocate users in User management, Press OK
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Go to Settings
-- Press OK
-- Log in
-- For more information, see Siemens Industry Online Support.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Go to Settings</li>
+    <li>Press OK</li>
+    <li>Log in</li>
+    <li>For more information, see Siemens Industry Online Support.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Go To Settings
-- Press OK
-- LOG IN
-- For more information, see Siemens industry online support.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Go To Settings</li>
+    <li>Press OK</li>
+    <li>LOG IN</li>
+    <li>For more information, see Siemens industry online support.</li>
+  </ul>
 </div>
 </div>
 
 ## Common UX wording mistakes
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- time zone
-- log file
-- log in (as an action)
-- login (as a noun)
-- equipment
-- feedback
-- training
-- current
-- avoid "shall"
-- Siemens has
-- 34 million / 35 billion
-- 34 million
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>time zone</li>
+    <li>log file</li>
+    <li>log in (as an action)</li>
+    <li>login (as a noun)</li>
+    <li>equipment</li>
+    <li>feedback</li>
+    <li>training</li>
+    <li>current</li>
+    <li>avoid "shall"</li>
+    <li>Siemens has</li>
+    <li>34 million / 35 billion</li>
+    <li>34 million</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- timezone
-- logfile
-- login
-- log in
-- equipments
-- feedbacks
-- trainings
-- actual
-- user shall manage users
-- Siemens have
-- 34’ / 35“
-- 34 millions
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>timezone</li>
+    <li>logfile</li>
+    <li>login</li>
+    <li>log in</li>
+    <li>equipments</li>
+    <li>feedbacks</li>
+    <li>trainings</li>
+    <li>actual</li>
+    <li>user shall manage users</li>
+    <li>Siemens have</li>
+    <li>34’ / 35“</li>
+    <li>34 millions</li>
+  </ul>
 </div>
 </div>

--- a/docs/guidelines/language/dialogs-and-buttons.md
+++ b/docs/guidelines/language/dialogs-and-buttons.md
@@ -24,20 +24,20 @@ description: 'Discover guidelines for writing dialogs and button labels to ensur
 
 - Only use ‘OK’ as an option if you cannot find an appropriate verb
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Title: Add user  / Buttons: Cancel, Add
-- Title: Delete file  / Buttons: Cancel, Delete
-- Title: Edit details  / Buttons: Cancel, Save
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Title: Add user  / Buttons: Cancel, Add</li>
+    <li>Title: Delete file  / Buttons: Cancel, Delete</li>
+    <li>Title: Edit details  / Buttons: Cancel, Save</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Title: Add user  / Buttons: Cancel, OK
-- Title: Are you sure  / Buttons: Cancel, Delete
-- Title: Edit details  / Buttons: Cancel, Edit
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Title: Add user  / Buttons: Cancel, OK</li>
+    <li>Title: Are you sure  / Buttons: Cancel, Delete</li>
+    <li>Title: Edit details  / Buttons: Cancel, Edit</li>
+  </ul>
 </div>
 </div>
 
@@ -47,15 +47,15 @@ description: 'Discover guidelines for writing dialogs and button labels to ensur
 
 - Primary actions can either be positive (Send, Save) or negative (Delete)
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Cancel, Save
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Cancel, Save</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Save, Cancel
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Save, Cancel</li>
+  </ul>
 </div>
 </div>

--- a/docs/guidelines/language/formatting/addresses.mdx
+++ b/docs/guidelines/language/formatting/addresses.mdx
@@ -12,40 +12,40 @@ description: In industrial applications, writing addresses clearly and consisten
 
 Use specific text field labels for different parts of the address.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Number | Street | State | ZIP code | Country
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Number | Street | State | ZIP code | Country</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Address line 1, Address line 2, Address line 3
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Address line 1, Address line 2, Address line 3</li>
+  </ul>
 </div>
 </div>
 
 Ensure special and international characters are accepted for international addresses.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 12-142 Elm St
-- #8C (unit or suite number)
-- Straße (street in German)
-- VI (unit for floor in German)
-- München (for Munich)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>12-142 Elm St</li>
+    <li>#8C (unit or suite number)</li>
+    <li>Straße (street in German)</li>
+    <li>VI (unit for floor in German)</li>
+    <li>München (for Munich)</li>
+  </ul>
 </div>
 </div>
 
 Use commas to separate names, streets, states and countries to prevent errors when there is only one text field.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- John Doe, 123 Maple Street, Springfield, California, 62704, United States
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>John Doe, 123 Maple Street, Springfield, California, 62704, United States</li>
+  </ul>
 </div>
 </div>
 
@@ -53,28 +53,28 @@ Use commas to separate names, streets, states and countries to prevent errors wh
 
 Use a comma between cities and states and other regions, e.g. cities within Cantons.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Springfield, Illinois
-- Munich, Bavaria
-- Thun, Bern
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Springfield, Illinois</li>
+    <li>Munich, Bavaria</li>
+    <li>Thun, Bern</li>
+  </ul>
 </div>
 </div>
 
 Use capital letters for abbreviated states without a full stop.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- IL
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>IL</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Il.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Il.</li>
+  </ul>
 </div>
 </div>
 
@@ -82,20 +82,20 @@ Use capital letters for abbreviated states without a full stop.
 
 Use the correct regional format for ZIP codes, including any necessary spaces or hyphens.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 90210 (US)
-- SW1A 2AA (UK)
-- 123-4567 (Japan)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>90210 (US)</li>
+    <li>SW1A 2AA (UK)</li>
+    <li>123-4567 (Japan)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 90 21 0 (US)
-- SW1A2AA (UK)
-- 1234567 (Japan)
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>90 21 0 (US)</li>
+    <li>SW1A2AA (UK)</li>
+    <li>1234567 (Japan)</li>
+  </ul>
 </div>
 </div>
 
@@ -119,34 +119,34 @@ Use common abbreviations for street types without full stops to avoid visual clu
 
 Add floor numbers either before or after the word and note different international floor counting systems.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Floor 3
-- 3rd floor
-- Ground floor (UK/Europe)
-- First floor (US)
-- Floor G (international)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Floor 3</li>
+    <li>3rd floor</li>
+    <li>Ground floor (UK/Europe)</li>
+    <li>First floor (US)</li>
+    <li>Floor G (international)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Floor 3rd
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Floor 3rd</li>
+  </ul>
 </div>
 </div>
 
 Use numbers and letters after buildings, suites, apartments, rooms and floors.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Building A
-- Building part
-- Room segment
-- Bldg A
-- Suite 3B
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Building A</li>
+    <li>Building part</li>
+    <li>Room segment</li>
+    <li>Bldg A</li>
+    <li>Suite 3B</li>
+  </ul>
 </div>
 </div>
 
@@ -154,14 +154,14 @@ Use numbers and letters after buildings, suites, apartments, rooms and floors.
 
 Use "Line" or add a description, e.g. "Assembly line" and use "Zone" or "Area" for larger facilities.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Assembly line 2
-- Line B
-- Zone C
-- Area 8
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Assembly line 2</li>
+    <li>Line B</li>
+    <li>Zone C</li>
+    <li>Area 8</li>
+  </ul>
 </div>
 </div>
 
@@ -169,35 +169,35 @@ Use "Line" or add a description, e.g. "Assembly line" and use "Zone" or "Area" f
 
 Use clear labels when possible with "Latitude" first, then "Longitude".
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Latitude: 48.14389° | Longitude: 11.57633°
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Latitude: 48.14389° | Longitude: 11.57633°</li>
+  </ul>
 </div>
 </div>
 
 Use plus (+), minus (-), a comma and a space when adding both in one text field.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- +48.14389°, +11.57633°
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>+48.14389°, +11.57633°</li>
+  </ul>
 </div>
 </div>
 
 Use the correct degree symbol (Unicode U+00B0).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- °
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>°</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- o
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>o</li>
+  </ul>
 </div>
 </div>

--- a/docs/guidelines/language/formatting/date.mdx
+++ b/docs/guidelines/language/formatting/date.mdx
@@ -14,46 +14,46 @@ description: Accurate dates and times are essential in industrial settings, serv
 
 Use the ISO 8601 date and time format standards when backend localization is not possible.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 2025-04-08 (April 8, 2025)
-- 14:30:00 (24-hour format)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>2025-04-08 (April 8, 2025)</li>
+    <li>14:30:00 (24-hour format)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 2025/04/08
-- 2:30 PM
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>2025/04/08</li>
+    <li>2:30 PM</li>
+  </ul>
 </div>
 </div>
 
 Add tooltips or in-line text to support users and clarify which format is being used.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- YYYY-MM-DD
-- 24-hour format
-- Times are formatted in 24-hour format as HH:MM. For example, 2:30 PM is written as 14:30.
-- Dates and times include time zones. For example, April 8, 2025, at 2:30 PM in Berlin is written as 2025-04-08T14:30:00+02:00.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>YYYY-MM-DD</li>
+    <li>24-hour format</li>
+    <li>Times are formatted in 24-hour format as HH:MM. For example, 2:30 PM is written as 14:30.</li>
+    <li>Dates and times include time zones. For example, April 8, 2025, at 2:30 PM in Berlin is written as 2025-04-08T14:30:00+02:00.</li>
+  </ul>
 </div>
 </div>
 
 Avoid adding unnecessary punctuation to abbreviated dates.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Jan
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Jan</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Jan.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Jan.</li>
+  </ul>
 </div>
 </div>
 
@@ -61,63 +61,63 @@ Avoid adding unnecessary punctuation to abbreviated dates.
 
 Write out full dates using commas to separate elements within longer texts and paragraphs.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Monday, January 12, 2025
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Monday, January 12, 2025</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Monday: January 12th: 2025
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Monday: January 12th: 2025</li>
+  </ul>
 </div>
 </div>
 
 Write out dates with the abbreviated form using dashes (hyphens) instead of slashes for better readability.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Dec-26-2025
-- Apr-09-2025
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Dec-26-2025</li>
+    <li>Apr-09-2025</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Apr/09/2025
-- Apr 09/2025
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Apr/09/2025</li>
+    <li>Apr 09/2025</li>
+  </ul>
 </div>
 </div>
 
 Write dates in tables using abbreviated months to avoid confusion and the need for further tooltips or explanation.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Apr-09
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Apr-09</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 04-09
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>04-09</li>
+  </ul>
 </div>
 </div>
 
 Avoid using "st" (as in 1st) or "th" (as in 5th) for a cleaner user interface.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Monday, January 12, 2025
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Monday, January 12, 2025</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Monday, January 12th, 2025
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Monday, January 12th, 2025</li>
+  </ul>
 </div>
 </div>
 
@@ -125,17 +125,17 @@ Avoid using "st" (as in 1st) or "th" (as in 5th) for a cleaner user interface.
 
 Start all days with a capital letter. Use three-letter abbreviations without punctuation when there isn’t enough space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Monday, Tuesday, Wednesday, etc.
-- Mon
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Monday, Tuesday, Wednesday, etc.</li>
+    <li>Mon</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Mon.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Mon.</li>
+  </ul>
 </div>
 </div>
 
@@ -143,18 +143,18 @@ Start all days with a capital letter. Use three-letter abbreviations without pun
 
 Avoid calendar weeks (CW) whenever possible as these are very specific to certain regions.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Week 15 (April 7 – April 13, 2025)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Week 15 (April 7 – April 13, 2025)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- CW 15 (15th week of the year)
-- CW 15/2025 (15th calendar week year 2025)
-- Calendar week 05 in year 2025
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>CW 15 (15th week of the year)</li>
+    <li>CW 15/2025 (15th calendar week year 2025)</li>
+    <li>Calendar week 05 in year 2025</li>
+  </ul>
 </div>
 </div>
 
@@ -162,17 +162,17 @@ Avoid calendar weeks (CW) whenever possible as these are very specific to certai
 
 Start all months with a capital letter. Use abbreviations without punctuation when there isn’t enough space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- January, February, March, etc.
-- Jan
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>January, February, March, etc.</li>
+    <li>Jan</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Jan.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Jan.</li>
+  </ul>
 </div>
 </div>
 
@@ -180,16 +180,16 @@ Start all months with a capital letter. Use abbreviations without punctuation wh
 
 Use the four-digit format and never abbreviate in industrial applications.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 2023
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>2023</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- ’23
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>’23</li>
+  </ul>
 </div>
 </div>
 
@@ -197,16 +197,16 @@ Use the four-digit format and never abbreviate in industrial applications.
 
 Use plural -s when talking about decades.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 1980s
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>1980s</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 1980’s
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>1980’s</li>
+  </ul>
 </div>
 </div>
 
@@ -214,16 +214,16 @@ Use plural -s when talking about decades.
 
 Use "th" and "nd" to reference centuries with ordinal numbers (sequencing) without using superscript.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Welcome to the 21st century of industrial innovation! Our app uses AI to deliver efficiency in your operations.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Welcome to the 21st century of industrial innovation! Our app uses AI to deliver efficiency in your operations.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Welcome to the 21<sup>st</sup> century of industrial innovation! Our app uses AI to deliver efficiency in your operations.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Welcome to the 21<sup>st</sup> century of industrial innovation! Our app uses AI to deliver efficiency in your operations.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/formatting/measurements.mdx
+++ b/docs/guidelines/language/formatting/measurements.mdx
@@ -12,56 +12,56 @@ description: In industrial settings, accurate measurements are vital for ensurin
 
 Use the same measurement format and style throughout your user interface and consider localization conflicts. Write out measurement abbreviations in full if there is any chance users will not understand.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- British Thermal Unit (BTU): 1
-- Nautical Mile (nmi): 8
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>British Thermal Unit (BTU): 1</li>
+    <li>Nautical Mile (nmi): 8</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- BTU: 1
-- nmi: 8
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>BTU: 1</li>
+    <li>nmi: 8</li>
+  </ul>
 </div>
 </div>
 
 Avoid line breaks between the value and the unit by using a protected (non-breaking) space. Use the singular when talking about a specific number and in abbreviations. Use lower case as the default for most unit abbreviations.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 200 kg
-- 20 kg
-- 4 in
-- 200 g
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>200 kg</li>
+    <li>20 kg</li>
+    <li>4 in</li>
+    <li>200 g</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 200kg
-- 20 kgs
-- 4 in.
-- 200 G
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>200kg</li>
+    <li>20 kgs</li>
+    <li>4 in.</li>
+    <li>200 G</li>
+  </ul>
 </div>
 </div>
 
 Use upper case for unit abbreviations named after people and lower case when the abbreviation is written out in full.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 6 volts
-- 6 V
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>6 volts</li>
+    <li>6 V</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 6 Volts
-- 6 v
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>6 Volts</li>
+    <li>6 v</li>
+  </ul>
 </div>
 </div>
 
@@ -77,17 +77,17 @@ Use upper case for unit abbreviations named after people and lower case when the
 
 Use a slash to show how compound units are divided for clarity.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- km/h
-- A/m
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>km/h</li>
+    <li>A/m</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- km-h
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>km-h</li>
+  </ul>
 </div>
 </div>
 
@@ -95,37 +95,37 @@ Use a slash to show how compound units are divided for clarity.
 
 Use "L" (liter) instead of lower case "l" only if there is any doubt users will confuse it with "1".
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 2 L
-- 11 L
-- 2 l
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>2 L</li>
+    <li>11 L</li>
+    <li>2 l</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 11 l
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>11 l</li>
+  </ul>
 </div>
 </div>
 
 Use upper case "B" to abbreviate byte and lower case "b" to abbreviate bit. Use M for mega, G for giga and T for tera to distinguish from m (milli), g (gram) and t (ton).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 120 MB (megabytes)
-- 120 Mb (megabits)
-- 1 t
-- 1 TB
-- 1 THz
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>120 MB (megabytes)</li>
+    <li>120 Mb (megabits)</li>
+    <li>1 t</li>
+    <li>1 TB</li>
+    <li>1 THz</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 1 T
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>1 T</li>
+  </ul>
 </div>
 </div>
 
@@ -133,48 +133,48 @@ Use upper case "B" to abbreviate byte and lower case "b" to abbreviate bit. Use 
 
 Use superscript to indicate cubed measurements.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- m³
-- cm³
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>m³</li>
+    <li>cm³</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- m3
-- cm3
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>m3</li>
+    <li>cm3</li>
+  </ul>
 </div>
 </div>
 
 Use the plain text caret symbol (^) when superscript is not possible in your application.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- m^3
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>m^3</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- m3
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>m3</li>
+  </ul>
 </div>
 </div>
 
 Use mcg to abbreviate microgram instead of the Greek letter mu (μ).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 1000 mcg
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>1000 mcg</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 1000 μg
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>1000 μg</li>
+  </ul>
 </div>
 </div>
 
@@ -182,32 +182,32 @@ Use mcg to abbreviate microgram instead of the Greek letter mu (μ).
 
 Use a non-breaking space (Ctrl + Shift + Space) between the number and the degree symbol.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 23 °C
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>23 °C</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 23°C
-- 23° C
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>23°C</li>
+    <li>23° C</li>
+  </ul>
 </div>
 </div>
 
 Use the degree symbol (°) before the initial letter of the temperature scale without a space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 23 °C
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>23 °C</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 23 C°
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>23 C°</li>
+  </ul>
 </div>
 </div>
 
@@ -215,20 +215,20 @@ Use the degree symbol (°) before the initial letter of the temperature scale wi
 
 Use "px" in lower case to abbreviate pixels with a space for readability without periods after px, pt and dpi (dots per inch).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 45 px
-- 1280 x 780 px
-- 4 pt
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>45 px</li>
+    <li>1280 x 780 px</li>
+    <li>4 pt</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 45PX
-- 1280x780px
-- 4pt.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>45PX</li>
+    <li>1280x780px</li>
+    <li>4pt.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/formatting/money.mdx
+++ b/docs/guidelines/language/formatting/money.mdx
@@ -13,87 +13,87 @@ description: 'Understanding money and currency is important for designing user i
 
 Place the currency symbol before the amount in English and use the same formatting style throughout.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- £320
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>£320</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 320£
-- £320/£320.00/Three hundred and twenty pounds/320 pounds (mixed styles)
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>320£</li>
+    <li>£320/£320.00/Three hundred and twenty pounds/320 pounds (mixed styles)</li>
+  </ul>
 </div>
 </div>
 
 Use decimal points for cents or smaller units within English user interfaces.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- €999.50
-- $400,456.50
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>€999.50</li>
+    <li>$400,456.50</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- €999,50
-- $400.456,50
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>€999,50</li>
+    <li>$400.456,50</li>
+  </ul>
 </div>
 </div>
 
 Never add a space between the currency symbol and the amount.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- $100
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>$100</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- $ 100
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>$ 100</li>
+  </ul>
 </div>
 </div>
 
 Use the ISO currency code before the number without a space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- USD400
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>USD400</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 300USD
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>300USD</li>
+  </ul>
 </div>
 </div>
 
 Use numbers and currency symbols within the UI when talking about marketing and pricing.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Thank you. Your payment of $50 has been processed.
-- Invest in our new soft sensors for $6,000 to boost your production efficiency.
-- Spare parts cost estimation for 2025 is $125,999.
-- The subscription costs $10 per month.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Thank you. Your payment of $50 has been processed.</li>
+    <li>Invest in our new soft sensors for $6,000 to boost your production efficiency.</li>
+    <li>Spare parts cost estimation for 2025 is $125,999.</li>
+    <li>The subscription costs $10 per month.</li>
+  </ul>
 </div>
 </div>
 
 Write out the full word in formal and legal documents.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- The total amount shall not exceed four thousand dollars.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>The total amount shall not exceed four thousand dollars.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/formatting/names-titles.mdx
+++ b/docs/guidelines/language/formatting/names-titles.mdx
@@ -14,18 +14,18 @@ description: Accurate and consistent use of names and titles is essential for ma
 
 Use "First name" and "Last name" in forms and ensure text fields accept names with only one letter.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- First name
-- Last name
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>First name</li>
+    <li>Last name</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Surname
-- Full name
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Surname</li>
+    <li>Full name</li>
+  </ul>
 </div>
 </div>
 
@@ -33,11 +33,11 @@ Use "First name" and "Last name" in forms and ensure text fields accept names wi
 
 Use first names to welcome users to applications.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Welcome Susanne
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Welcome Susanne</li>
+  </ul>
 </div>
 </div>
 
@@ -45,16 +45,16 @@ Use first names to welcome users to applications.
 
 Avoid gendered titles unless absolutely necessary for your application. Use "Title", not "Honorific", to describe words such as Mr. and Mrs. Note that not all cultures have equivalents to some titles used in the United States, such as Ms.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- [ Mr. | Ms. | Mx. | None | Other | Prefer not to say]
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>[ Mr. | Ms. | Mx. | None | Other | Prefer not to say]</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- [ Mr. | Mrs. | Miss | Ms. ]
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>[ Mr. | Mrs. | Miss | Ms. ]</li>
+  </ul>
 </div>
 </div>
 
@@ -62,45 +62,45 @@ Avoid gendered titles unless absolutely necessary for your application. Use "Tit
 
 Use full stops for all abbreviated titles in American English.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Mr. Smith
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Mr. Smith</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Mr Smith
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Mr Smith</li>
+  </ul>
 </div>
 </div>
 
 Use titles with full names or surnames but do not use titles when addressing users with only their first name.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Mrs. Turner
-- Mrs. Jennifer Turner
-- Jennifer
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Mrs. Turner</li>
+    <li>Mrs. Jennifer Turner</li>
+    <li>Jennifer</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Mrs. Jennifer
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Mrs. Jennifer</li>
+  </ul>
 </div>
 </div>
 
 Use full stops for all abbreviated professional titles in American English.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Dr.
-- Prof.
-- Eng.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Dr.</li>
+    <li>Prof.</li>
+    <li>Eng.</li>
+  </ul>
 </div>
 </div>
 
@@ -108,50 +108,50 @@ Use full stops for all abbreviated professional titles in American English.
 
 Use capital letters for corporate titles especially with the name and use capital letters for corporate title acronyms.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Chief Financial Officer Teresa Lopez
-- Teresa Lopez (Chief Financial Officer)
-- Teresa Lopez (CFO)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Chief Financial Officer Teresa Lopez</li>
+    <li>Teresa Lopez (Chief Financial Officer)</li>
+    <li>Teresa Lopez (CFO)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- chief financial officer Teresa Lopez
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>chief financial officer Teresa Lopez</li>
+  </ul>
 </div>
 </div>
 
 Use lower case when titles are used generically (without a name) and separate titles from names with a comma.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- The chief financial officer for the company will hold a press conference tomorrow.
-- The project manager needs to schedule maintenance.
-- Carol Jones, Chairwoman of the Supervisory Board, spoke at the press conference yesterday.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>The chief financial officer for the company will hold a press conference tomorrow.</li>
+    <li>The project manager needs to schedule maintenance.</li>
+    <li>Carol Jones, Chairwoman of the Supervisory Board, spoke at the press conference yesterday.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Call the Manager.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Call the Manager.</li>
+  </ul>
 </div>
 </div>
 
 Always capitalize Managing Board and use lower case for "member".
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- John Smith is a member of the Managing Board.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>John Smith is a member of the Managing Board.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- John Smith is a member of the managing board.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>John Smith is a member of the managing board.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/formatting/numbers.mdx
+++ b/docs/guidelines/language/formatting/numbers.mdx
@@ -14,76 +14,76 @@ description: In industrial settings, numbers and percentages are key to tracking
 
 Write "Number" or "number" when there is enough space within the user interface.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Number
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Number</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Num.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Num.</li>
+  </ul>
 </div>
 </div>
 
 Use "No." as an abbreviation for number with a period and without a space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- No.6
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>No.6</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Num.6
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Num.6</li>
+  </ul>
 </div>
 </div>
 
 Avoid using the # symbol with numbers.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Number 6
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Number 6</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- #6
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>#6</li>
+  </ul>
 </div>
 </div>
 
 Write numbers as digits, such as "9" instead of "nine", in industrial user interfaces.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- We’ve released 3 new features this month.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>We’ve released 3 new features this month.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- We’ve released three new features this month.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>We’ve released three new features this month.</li>
+  </ul>
 </div>
 </div>
 
 Write numbers with four digits and more with commas to separate thousands, millions, etc. in American English.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 100,000
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>100,000</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 100.000
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>100.000</li>
+  </ul>
 </div>
 </div>
 
@@ -91,53 +91,53 @@ Write numbers with four digits and more with commas to separate thousands, milli
 
 Use en dashes (–) instead of hyphens (-) for ranges.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 10–0
-- The shipment weighs 50–75kg
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>10–0</li>
+    <li>The shipment weighs 50–75kg</li>
+  </ul>
 </div>
 </div>
 
 Write out the unit only once in ranges.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- The temperature fluctuated between 20–25°C
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>The temperature fluctuated between 20–25°C</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- The temperature fluctuated between 20°C–25°C
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>The temperature fluctuated between 20°C–25°C</li>
+  </ul>
 </div>
 </div>
 
 Use the minus hyphen for negative numbers which is better aligned than a normal hyphen (Unicode U+2212).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- -12
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>-12</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- —12
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>—12</li>
+  </ul>
 </div>
 </div>
 
 Use either "to" or separate text fields for ranges with minus numbers for readability.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- -12 to -15°C
-- Min temp (C): -12° / Max temp (C): -15°
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>-12 to -15°C</li>
+    <li>Min temp (C): -12° / Max temp (C): -15°</li>
+  </ul>
 </div>
 </div>
 
@@ -145,20 +145,20 @@ Use either "to" or separate text fields for ranges with minus numbers for readab
 
 Write decimals using a period (.) to separate the whole number from the fractional part in American English.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 0.5
-- 5,245.15
-- 2.5 million
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>0.5</li>
+    <li>5,245.15</li>
+    <li>2.5 million</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 0,5
-- 5.245,15
-- 2,5 million
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>0,5</li>
+    <li>5.245,15</li>
+    <li>2,5 million</li>
+  </ul>
 </div>
 </div>
 
@@ -167,76 +167,75 @@ Write decimals using a period (.) to separate the whole number from the fraction
 Use "K" as an abbreviation for thousand, "M" for million, and "B" for billion without a period or space. Consider variations in other languages and never use abbreviations when there is doubt.
 
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 34K
-- 34M
-- 34B
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>34K</li>
+    <li>34M</li>
+    <li>34B</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 34 k
-- 34 mil
-- 34 bill
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>34 k</li>
+    <li>34 mil</li>
+    <li>34 bill</li>
+  </ul>
 </div>
 </div>
 
 Use the singular "million" when talking about a specific number.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 34 million
-- Our system processes one million connections.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>34 million</li>
+    <li>Our system processes one million connections.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 34 millions
-- Our system processes one millions connections.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>34 millions</li>
+    <li>Our system processes one millions connections.</li>
+  </ul>
 </div>
 </div>
 
 Use the plural "millions" when talking about an unspecific number.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Our goal is to deliver software to millions of happy users worldwide.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Our goal is to deliver software to millions of happy users worldwide.</li>
+  </ul>
 </div>
 </div>
 
 Write out numbers in the millions and billions ("one million" instead of "1,000,000") in longer texts and paragraphs.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- We have over one million users worldwide.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>We have over one million users worldwide.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- We have over 1,000,000 users worldwide.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>We have over 1,000,000 users worldwide.</li>
+  </ul>
 </div>
 </div>
 
 Use numerals for numbers in the millions for dates, addresses, units of measurement, currencies and percentages.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- The temperature can reach 1,000,000°C in the pod.
-- The cargo ship can carry up to 1,000,000kg.
-
-- The success rate of our new implementation is 1,000,000%.
-- The project budget is $1,000,000.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>The temperature can reach 1,000,000°C in the pod.</li>
+    <li>The cargo ship can carry up to 1,000,000kg.</li>
+    <li>The success rate of our new implementation is 1,000,000%.</li>
+    <li>The project budget is $1,000,000.</li>
+  </ul>
 </div>
 </div>
 
@@ -244,31 +243,31 @@ Use numerals for numbers in the millions for dates, addresses, units of measurem
 
 Use the % symbol instead of writing out "percentage" within the user interface to save space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 10%
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>10%</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 10 percent
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>10 percent</li>
+  </ul>
 </div>
 </div>
 
 Use % after the number and without a space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 10%
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>10%</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- %10
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>%10</li>
+  </ul>
 </div>
 </div>
 
@@ -276,29 +275,29 @@ Use % after the number and without a space.
 
 Separate phone numbers into groups for clarity when backend localization or separate fields are not possible.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Country code, area code, numbers in groupings of 3 or 4
-- 0044, 208, 899 7032
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Country code, area code, numbers in groupings of 3 or 4</li>
+    <li>0044, 208, 899 7032</li>
+  </ul>
 </div>
 </div>
 
 Use the plus symbol (+) or "00" before the country code and show extension numbers with a hyphen.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- +49 123 456 7890
-- 0049 123 456 7890
-- 0123 456 7890-12
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>+49 123 456 7890</li>
+    <li>0049 123 456 7890</li>
+    <li>0123 456 7890-12</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 0123 456 7890 12
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>0123 456 7890 12</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/formatting/software-versions.mdx
+++ b/docs/guidelines/language/formatting/software-versions.mdx
@@ -13,127 +13,127 @@ description: 'Consistency in writing about versions builds trust and helps users
 
 Write "version" in full without abbreviating when there is enough space within the user interface.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Version 2.12.6
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Version 2.12.6</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- ver 2.12.6
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>ver 2.12.6</li>
+  </ul>
 </div>
 </div>
 
 Use "Version" with a capital V when it starts a sentence.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Version 3.5.1 has three new exciting changes.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Version 3.5.1 has three new exciting changes.</li>
+  </ul>
 </div>
 </div>
 
 Use "Version" with a capital V when referring to a named release or is used as a label.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Our migration guide for moving from Version 2 to Version 3 is below.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Our migration guide for moving from Version 2 to Version 3 is below.</li>
+  </ul>
 </div>
 </div>
 
 Use "version" with a lower case "v" when talking about unspecified versions as it is not a proper noun.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Our next version contains three new exciting changes.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Our next version contains three new exciting changes.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Our next Version contains three new exciting changes.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Our next Version contains three new exciting changes.</li>
+  </ul>
 </div>
 </div>
 
 Use a capital V without spacing between the letter and number to abbreviate versions.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- V2.1.0
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>V2.1.0</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- v2.1.0
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>v2.1.0</li>
+  </ul>
 </div>
 </div>
 
 Start the first major release with 1 (not 01).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- V1.0.0
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>V1.0.0</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- V01.0.0
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>V01.0.0</li>
+  </ul>
 </div>
 </div>
 
 End versions without a full stop at the end.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- V1.0.0
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>V1.0.0</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- V1.0.0.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>V1.0.0.</li>
+  </ul>
 </div>
 </div>
 
 Use single digits without adding extra zeros to make it easier to read.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- V3.2.5
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>V3.2.5</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- V03.02.05
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>V03.02.05</li>
+  </ul>
 </div>
 </div>
 
 Add identifiers, such as alpha, before or after version numbers for pre-releases.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- V1.0.0-beta
-- Beta V5.2
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>V1.0.0-beta</li>
+    <li>Beta V5.2</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- V1.0.0-Beta
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>V1.0.0-Beta</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/formatting/timezones.mdx
+++ b/docs/guidelines/language/formatting/timezones.mdx
@@ -15,50 +15,50 @@ description: Time and time-related guidelines help prevent misunderstandings and
 
 Use the 24-hour clock system (the ISO 8601 time standards) when backend localization is not possible.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 11:00
-- 23:00
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>11:00</li>
+    <li>23:00</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 11am
-- 11PM
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>11am</li>
+    <li>11PM</li>
+  </ul>
 </div>
 </div>
 
 Use colons (:) to split times between hours, minutes, and seconds.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- hh:mm:ss
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>hh:mm:ss</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- hh.mm.ss
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>hh.mm.ss</li>
+  </ul>
 </div>
 </div>
 
 Use periods (.) to add milliseconds and nanoseconds, not a colon (:) according to ISO standards.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- hh:mm:ss.mms
-- hh:mm:ss.sss (ISO 8601 standard)
-- 0:00:00.920
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>hh:mm:ss.mms</li>
+    <li>hh:mm:ss.sss (ISO 8601 standard)</li>
+    <li>0:00:00.920</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 0:00:00:920
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>0:00:00:920</li>
+  </ul>
 </div>
 </div>
 
@@ -66,27 +66,27 @@ Use periods (.) to add milliseconds and nanoseconds, not a colon (:) according t
 
 Use an en (–) dash to represent time ranges and intervals without spacing on either side of the dash.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Routine maintenance: 08:00–11:00
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Routine maintenance: 08:00–11:00</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Packaging line active: 10:00-18:00
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Packaging line active: 10:00-18:00</li>
+  </ul>
 </div>
 </div>
 
 Use "from" and "to" for time ranges with separate text or input fields.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- From: 14:00
-- To: 15:00
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>From: 14:00</li>
+    <li>To: 15:00</li>
+  </ul>
 </div>
 </div>
 
@@ -94,13 +94,13 @@ Use "from" and "to" for time ranges with separate text or input fields.
 
 Use numerals to write about durations with the full or abbreviated time unit (depending on space in the UI).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Each shift lasts 8 hrs.
-- Routine maintenance takes approximately 1 hour 30 minutes.
-- Cooling period: 20 minutes
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Each shift lasts 8 hrs.</li>
+    <li>Routine maintenance takes approximately 1 hour 30 minutes.</li>
+    <li>Cooling period: 20 minutes</li>
+  </ul>
 </div>
 </div>
 
@@ -108,127 +108,127 @@ Use numerals to write about durations with the full or abbreviated time unit (de
 
 Write "time zone" as two words, not one word "timezone".
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Select time zone
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Select time zone</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Select timezone
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Select timezone</li>
+  </ul>
 </div>
 </div>
 
 When writing out the full time zone, add the UTC offset in brackets afterwards.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- British Summer Time (UTC+1)
-- Central European Summer Time (UTC+2)
-- Eastern European Summer Time (UTC+3)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>British Summer Time (UTC+1)</li>
+    <li>Central European Summer Time (UTC+2)</li>
+    <li>Eastern European Summer Time (UTC+3)</li>
+  </ul>
 </div>
 </div>
 
 Use abbreviated time zones with or without the UTC offset within the UI to save space.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- EST
-- EST (UTC +3)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>EST</li>
+    <li>EST (UTC +3)</li>
+  </ul>
 </div>
 </div>
 
 Give time zones capital letters for each word.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Eastern Standard Time
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Eastern Standard Time</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- eastern standard time
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>eastern standard time</li>
+  </ul>
 </div>
 </div>
 
 Give abbreviated time zones capital letters.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- EST
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>EST</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- est
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>est</li>
+  </ul>
 </div>
 </div>
 
 Avoid punctuation when writing time zones.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- EST
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>EST</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- EST.
-- E.S.T.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>EST.</li>
+    <li>E.S.T.</li>
+  </ul>
 </div>
 </div>
 
 Add a space between the time and the time zone.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 15:23 EST
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>15:23 EST</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 15:23EST
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>15:23EST</li>
+  </ul>
 </div>
 </div>
 
 Write location and UTC offset in this order: city, country (UTC offset).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Berlin, Germany (UTC+1)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Berlin, Germany (UTC+1)</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- (UTC+1) Berlin, Germany
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>(UTC+1) Berlin, Germany</li>
+  </ul>
 </div>
 </div>
 
 Present multiple time zones clearly by using either "Local time" or "Your local time" for emphasis.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Meeting time: 2025-04-08 14:00 (Berlin, UTC+01:00)<br/>Your local time: 2025-04-08 21:00 (Tokyo, UTC+09:00)
-- Support hours (New York): 09:00 - 17:00 (UTC-04:00)<br/>Your local time (Sydney): 23:00 - 07:00 (UTC+10:00)
-- Deadline (San Francisco): 2025-04-08 17:00 (UTC-07:00)<br/>Your Local Time (Berlin): 2025-04-09 02:00 (UTC+01:00)
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Meeting time: 2025-04-08 14:00 (Berlin, UTC+01:00)<br/>Your local time: 2025-04-08 21:00 (Tokyo, UTC+09:00)</li>
+    <li>Support hours (New York): 09:00 - 17:00 (UTC-04:00)<br/>Your local time (Sydney): 23:00 - 07:00 (UTC+10:00)</li>
+    <li>Deadline (San Francisco): 2025-04-08 17:00 (UTC-07:00)<br/>Your Local Time (Berlin): 2025-04-09 02:00 (UTC+01:00)</li>
+  </ul>
 </div>
 </div>
 
@@ -236,42 +236,42 @@ Present multiple time zones clearly by using either "Local time" or "Your local 
 
 Use "current" for active, ongoing states and avoid "actual" when referring to time.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Current temperature: 72°F
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Current temperature: 72°F</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Actual temperature: 72°F
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Actual temperature: 72°F</li>
+  </ul>
 </div>
 </div>
 
 Use "latest" for the newest updates or versions and "last" for final items in a sequence.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Latest firmware update: V2.1.5
-- Last firmware update before end of life: V2.1.5
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Latest firmware update: V2.1.5</li>
+    <li>Last firmware update before end of life: V2.1.5</li>
+  </ul>
 </div>
 </div>
 
 Use "recent" for past events that have just happened.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Recent alerts: 2 warnings
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Recent alerts: 2 warnings</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Recent firmware update: V2.1.5
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Recent firmware update: V2.1.5</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/frequent-app-functions.md
+++ b/docs/guidelines/language/frequent-app-functions.md
@@ -18,13 +18,13 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Cockpit
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Console
-- Dash
-- Control panel
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Console</li>
+    <li>Dash</li>
+    <li>Control panel</li>
+  </ul>
 </div>
 </div>
 
@@ -34,12 +34,12 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Anomaly detection
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Assessment
-- Examination
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Assessment</li>
+    <li>Examination</li>
+  </ul>
 </div>
 </div>
 
@@ -53,11 +53,11 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Remove from watchlist
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Watch list
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Watch list</li>
+  </ul>
 </div>
 </div>
 
@@ -69,12 +69,12 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Details
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Facts
-- Specifics
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Facts</li>
+    <li>Specifics</li>
+  </ul>
 </div>
 </div>
 
@@ -120,11 +120,11 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Drag files here or select files
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Drag and drop here or browse
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Drag and drop here or browse</li>
+  </ul>
 </div>
 </div>
 
@@ -138,11 +138,11 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Write your comments here
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Write a comment
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Write a comment</li>
+  </ul>
 </div>
 </div>
 
@@ -168,13 +168,13 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Notify me when X occurs
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Error
-- Issue
-- Problem
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Error</li>
+    <li>Issue</li>
+    <li>Problem</li>
+  </ul>
 </div>
 </div>
 
@@ -204,14 +204,14 @@ description: 'Get tips for naming common app functions clearly and effectively. 
 
 - Detected
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-
-- Unacklowedged
-- Unack.
-- Unackn.
-- Unacknl.
-
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Unacklowedged</li>
+    <li>Unack.</li>
+    <li>Unackn.</li>
+    <li>Unacknl.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/grammar-and-vocabulary.md
+++ b/docs/guidelines/language/grammar-and-vocabulary.md
@@ -16,41 +16,41 @@ description: "Discover the importance of proper grammar and vocabulary in UX wri
 
 - Only use simple verb forms in the past or future when necessary
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- click, browse, upload
-- file loads, file loaded
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>click, browse, upload</li>
+    <li>file loads, file loaded</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- clicking, being clicked, was clicking
-- file is going to be loaded, file has been loaded
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>clicking, being clicked, was clicking</li>
+    <li>file is going to be loaded, file has been loaded</li>
+  </ul>
 </div>
 </div>
 
 ## Active voice
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Configuration file opens.
-- Admin provides read-only access.
-- Measure performance.
-- Click submit.
-- Calculate the data.
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Configuration file opens.</li>
+    <li>Admin provides read-only access.</li>
+    <li>Measure performance.</li>
+    <li>Click submit.</li>
+    <li>Calculate the data.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- The configuration file is opened.
-- Read-only access is provided by Admin.
-- Performance is measured.
-- Submit is clicked by user.
-- The data is calculated by application.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>The configuration file is opened.</li>
+    <li>Read-only access is provided by Admin.</li>
+    <li>Performance is measured.</li>
+    <li>Submit is clicked by user.</li>
+    <li>The data is calculated by application.</li>
+  </ul>
 </div>
 </div>
 
@@ -62,18 +62,18 @@ description: "Discover the importance of proper grammar and vocabulary in UX wri
 
 - Basic terminology: checkbox, drop-down, field, icon, menu, link, radio button, window
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- click
-- hover
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>click</li>
+    <li>hover</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- press
-- mouse over
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>press</li>
+    <li>mouse over</li>
+  </ul>
 </div>
 </div>
 
@@ -85,22 +85,22 @@ description: "Discover the importance of proper grammar and vocabulary in UX wri
 
 - Avoid cultural references
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- remove
-- calculate
-- continue
-- mobile device
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>remove</li>
+    <li>calculate</li>
+    <li>continue</li>
+    <li>mobile device</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- get rid of
-- add up
-- carry on
-- Apple, Android, iOS, smartphone
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>get rid of</li>
+    <li>add up</li>
+    <li>carry on</li>
+    <li>Apple, Android, iOS, smartphone</li>
+  </ul>
 </div>
 </div>
 
@@ -124,22 +124,22 @@ description: "Discover the importance of proper grammar and vocabulary in UX wri
 
 - Never make up your own acronyms: https://www.acronymfinder.com/
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- light emitting diodes (LEDs)
-- APS
-- EU
-- I/O component, I/O list, I/O module
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>light emitting diodes (LEDs)</li>
+    <li>APS</li>
+    <li>EU</li>
+    <li>I/O component, I/O list, I/O module</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Light Emitting Diodes (LEDS)
-- A.P.S.
-- E.U.
-- IO component, i/o list, I-O module
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Light Emitting Diodes (LEDS)</li>
+    <li>A.P.S.</li>
+    <li>E.U.</li>
+    <li>IO component, i/o list, I-O module</li>
+  </ul>
 </div>
 </div>
 
@@ -151,19 +151,19 @@ description: "Discover the importance of proper grammar and vocabulary in UX wri
 
 - Recent is more time focused and is similar to latest. It means that it happened a short time ago.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- Latest update
-- Latest summary
-- Recent events
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Latest update</li>
+    <li>Latest summary</li>
+    <li>Recent events</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- Last update
-- Last summary
-- Last events
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Last update</li>
+    <li>Last summary</li>
+    <li>Last events</li>
+  </ul>
 </div>
 </div>

--- a/docs/guidelines/language/grammar-and-vocabulary.md
+++ b/docs/guidelines/language/grammar-and-vocabulary.md
@@ -151,15 +151,15 @@ description: "Discover the importance of proper grammar and vocabulary in UX wri
 
 - Recent is more time focused and is similar to latest. It means that it happened a short time ago.
 
-<div className="dos-and-donts">
-<div className="dos">
+<div class="dos-and-donts">
+<div class="dos">
   <ul aria-label="Recommended practices">
     <li>Latest update</li>
     <li>Latest summary</li>
     <li>Recent events</li>
   </ul>
 </div>
-<div className="donts">
+<div class="donts">
   <ul aria-label="Practices to avoid">
     <li>Last update</li>
     <li>Last summary</li>

--- a/docs/guidelines/language/menu-functions-and-ui-labels/external-links-and-resources.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/external-links-and-resources.md
@@ -21,61 +21,79 @@ import { iconOpenExternal } from "@siemens/ix-icons/icons";
 
 Use brief, meaningful link text to explain the function of the target web page or resource.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- SIMATIC S7-1500 firmware updates <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
-- Roles and permissions in the documentation <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
-- Demonstration projects <IxIcon name={iconApplicationScreen} size="16" aria-label="external application" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>SIMATIC S7-1500 firmware updates <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+    <li>Roles and permissions in the documentation <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+    <li>Demonstration projects <IxIcon name={iconApplicationScreen} size="16" aria-label="external application" role="img"></IxIcon></li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Learn about the latest device firmware updates
-- {'https://www.company.com/s7-1500-firmware'}
-- Remote access
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Learn about the latest device firmware updates</li>
+    <li>{'https://www.company.com/s7-1500-firmware'}</li>
+    <li>Remote access</li>
+  </ul>
 </div>
 </div>
 
 Pair link text with universal icons, e.g. the open-external or application-screen icons.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Company Digital ID <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
-- Manage your software licenses in one place <IxIcon name={iconApplicationScreen} size="16" aria-label="external application" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Company Digital ID <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+    <li>Manage your software licenses in one place <IxIcon name={iconApplicationScreen} size="16" aria-label="external application" role="img"></IxIcon></li>
+  </ul>
 </div>
 </div>
 
 Use descriptive link text instead of long, full URLs and remove the prefix {'https://www'}.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Company homepage <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
-- acronymfinder.com <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Company homepage <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+    <li>acronymfinder.com <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- {'https://www.company.com/s9-1600-firmware'}<br/>
-- {'https://support.com/us/en/view/107826255'}
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>{'https://www.company.com/s9-1600-firmware'}<br/></li>
+    <li>{'https://support.com/us/en/view/107826255'}</li>
+  </ul>
 </div>
 </div>
 
 Avoid generic link text, e.g. "click here" without context or information regarding what opens.
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Description: The details regarding the collection and use of Analytics Data are described in Software Analytics Notice contained in the Application Function Manual.<br/><br/>
-Link text: Open Application Function Manual
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Description: The details regarding the collection and use of Analytics Data are described in Software Analytics Notice contained in the Application Function Manual.<br/><br/>
+    Link text: Open Application Function Manual</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Click here
-- Read more
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Click here</li>
+    <li>Read more</li>
+  </ul>
 </div>
 </div>
 
 Use unique link text for each link destination so assistive technology users can distinguish between links (if all links have the same text, it makes it hard to know where each one leads).
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Open Assembly Manual<br/>Open Demonstration Project App<br/>Explore Manual
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Open Assembly Manual<br/>Open Demonstration Project App<br/>Explore Manual</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Click here<br/>Click here<br/>Click here
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Click here<br/>Click here<br/>Click here</li>
+  </ul>
 </div>
 </div>
 
@@ -83,24 +101,30 @@ Use unique link text for each link destination so assistive technology users can
 
 Use brief, meaningful resource texts and explain the function and type of the resource.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Generative AI chat privacy information <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon>
-- Interface module IM 155-5 MF HF Equipment Manual <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon>
-- Industrial Copilots with Agentic AI <IxIcon name={iconVideoFile} size="16" aria-label="video" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Generative AI chat privacy information <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon></li>
+    <li>Interface module IM 155-5 MF HF Equipment Manual <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon></li>
+    <li>Industrial Copilots with Agentic AI <IxIcon name={iconVideoFile} size="16" aria-label="video" role="img"></IxIcon></li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- example.company.com/downloads/file.pdf
-- You can read more in the User Documentation
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>example.company.com/downloads/file.pdf</li>
+    <li>You can read more in the User Documentation</li>
+  </ul>
 </div>
 </div>
 
 Pair resource text with icons, e.g. PDF-document or video-file icons.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Data Privacy Organization <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon>
-- Industrial Copilots with Agentic AI <IxIcon name={iconVideoFile} size="16" aria-label="video" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Data Privacy Organization <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon></li>
+    <li>Industrial Copilots with Agentic AI <IxIcon name={iconVideoFile} size="16" aria-label="video" role="img"></IxIcon></li>
+  </ul>
 </div>
 </div>
 
@@ -108,9 +132,11 @@ Pair resource text with icons, e.g. PDF-document or video-file icons.
 
 Pair the download of resources with both file type and size whenever possible.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Download User Manual (54 MB) <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Download User Manual (54 MB) <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon></li>
+  </ul>
 </div>
 </div>
 
@@ -118,14 +144,18 @@ Pair the download of resources with both file type and size whenever possible.
 
 Describe link behavior and type in ALT-texts instead of repeating icon and visible link text.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Link text: Visit our homepage <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>ALT-text: external
-- Resource text: Function Manual <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon><br/>ALT-text: external PDF
-- Resource text:<br/> Industrial Copilots with Agentic AI <IxIcon name={iconVideoFile} size="16" aria-label="video" role="img"></IxIcon><br/>ALT-text: external video in new tab
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Link text: Visit our homepage <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>ALT-text: external</li>
+    <li>Resource text: Function Manual <IxIcon name={iconPdfDocument} size="16" aria-label="PDF" role="img"></IxIcon><br/>ALT-text: external PDF</li>
+    <li>Resource text:<br/> Industrial Copilots with Agentic AI <IxIcon name={iconVideoFile} size="16" aria-label="video" role="img"></IxIcon><br/>ALT-text: external video in new tab</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Link text: Visit our homepage <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>ALT-text: Visit our homepage.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Link text: Visit our homepage <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>ALT-text: Visit our homepage.</li>
+  </ul>
 </div>
 </div>
 
@@ -142,10 +172,12 @@ Describe link behavior and type in ALT-texts instead of repeating icon and visib
 
 Specify the language when the resource language differs from the app language (WCAG 3.1.2).
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Application Function Manual (German) <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
-- German web page (German) <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Application Function Manual (German) <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+    <li>German web page (German) <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+  </ul>
 </div>
 </div>
 
@@ -153,23 +185,29 @@ Specify the language when the resource language differs from the app language (W
 
 Separate external links from body text with lists to avoid disrupting user reading flow.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Our platform integrates with various tools to enhance productivity.<br/>
-External resources:<br/> Documentation portal <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>
-GitHub repository <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>
-Support community <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Our platform integrates with various tools to enhance productivity.<br/>
+    External resources:<br/> Documentation portal <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>
+    GitHub repository <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon><br/>
+    Support community <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+  </ul>
 </div>
 </div>
 
 Split external links from body text with separate paragraphs for faster scanning and enhanced transparency.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Description: Our new automation system improves efficiency by 40% and reduces downtime through predictive maintenance algorithms.<br/><br/>Link text: Efficiency report <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Description: Our new automation system improves efficiency by 40% and reduces downtime through predictive maintenance algorithms.<br/><br/>Link text: Efficiency report <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon></li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- For more technical details, visit Automation Whitepaper <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>For more technical details, visit Automation Whitepaper <IxIcon name={iconOpenExternal} size="16" aria-label="external" role="img"></IxIcon>.</li>
+  </ul>
 </div>
 </div>
 
@@ -177,24 +215,30 @@ Split external links from body text with separate paragraphs for faster scanning
 
 Avoid adding the "mailto" text and for email addresses as this is no longer visible in the UI.
 
-<div className="dos-and-donts" markdown>
-<div className="donts" markdown>
-- {'mailto:name@examples.com'}
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>{'mailto:name@examples.com'}</li>
+  </ul>
 </div>
 </div>
 
 Ensure email addresses and phone numbers are clickable.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- You can reach us at the following telephone number [+1 555-0100](#).
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>You can reach us at the following telephone number [+1 555-0100](#).</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- 555 0100
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>555 0100</li>
+  </ul>
 </div>
 </div>
 
-## Dos and Don'ts
+## Dos and Don’ts
 
 - Do add link text for transparency
 - Do pair link and resource icons with clear texts

--- a/docs/guidelines/language/menu-functions-and-ui-labels/external-links-and-resources.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/external-links-and-resources.md
@@ -240,12 +240,16 @@ Ensure email addresses and phone numbers are clickable.
 
 ## Dos and Don’ts
 
-- Do add link text for transparency
-- Do pair link and resource icons with clear texts
-- Do use icons to visualize what will open, e.g. external link, PDF, etc.
-- Do use ALT-text to explain icons
-- Don't include https://, http: or www in URL text
-- Don't add links in headings or sub-headings
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do add link text for transparency</li>
+      <li>Do pair link and resource icons with clear texts</li>
+      <li>Do use icons to visualize what will open, e.g. external link, PDF, etc.</li>
+      <li>Do use ALT-text to explain icons</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/license-management.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/license-management.md
@@ -485,9 +485,19 @@ Use “basic” product when talking about a simplified or entry-level version o
 
 ## Dos and Don’ts
 
-- Do document license terms and record any changes for consistency
-- Do use the same license actions consistently across applications and portfolios
-- Don’t create new license types or states, instead use standard terms
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do document license terms and record any changes for consistency</li>
+      <li>Do use the same license actions consistently across applications and portfolios</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t create new license types or states, instead use standard terms</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/license-management.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/license-management.md
@@ -14,32 +14,42 @@ description: 'Clear license and subscription management writing reduces user con
 
 Use clear and consistent language your users are familiar with.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Your subscription expires in 30 days. Renew now to keep access to all features.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Your subscription expires in 30 days. Renew now to keep access to all features.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Your entitlement terminates in 30 days. Execute renewal procedures to maintain feature provisioning.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your entitlement terminates in 30 days. Execute renewal procedures to maintain feature provisioning.</li>
+  </ul>
 </div>
 </div>
 
 Use the same terms throughout workflows, applications and portfolios to avoid confusion.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Activate your license / License activated / View activated licenses
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Activate your license / License activated / View activated licenses</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Activate your license / License enabled / View dynamic licenses
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Activate your license / License enabled / View dynamic licenses</li>
+  </ul>
 </div>
 </div>
 
 Use links when referencing terms of use or compliance documents.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- By using this software, you agree to our Terms of Use.<br/>
-Link text: View full terms
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>By using this software, you agree to our Terms of Use.<br/>
+    Link text: View full terms</li>
+  </ul>
 </div>
 </div>
 
@@ -47,68 +57,90 @@ Link text: View full terms
 
 Use American English spelling “license” (with s) for both nouns and verbs in all global interfaces.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Your license expires in 30 days.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Your license expires in 30 days.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Your licence expires in 30 days.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your licence expires in 30 days.</li>
+  </ul>
 </div>
 </div>
 
 Use “a license” when referring to single licenses in general, and “the license” when referring to specific licenses.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- You need a license to access this feature.
-- The license you purchased includes 5 users.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>You need a license to access this feature.</li>
+    <li>The license you purchased includes 5 users.</li>
+  </ul>
 </div>
 </div>
 
 Avoid using apostrophes to describe singular (‘s) or plural (s’) license possession.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- The license expires on May 1, 2026.
-- The status of all licenses can be viewed here.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>The license expires on May 1, 2026.</li>
+    <li>The status of all licenses can be viewed here.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- The license’s expiration date is May 1, 2026.
-- All licenses’ status can be viewed here.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>The license’s expiration date is May 1, 2026.</li>
+    <li>All licenses’ status can be viewed here.</li>
+  </ul>
 </div>
 </div>
 
 Use active voice for user actions.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Activate your license now.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Activate your license now.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Your license should be activated by you.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your license should be activated by you.</li>
+  </ul>
 </div>
 </div>
 
 Use passive voice when the actor is unknown or unimportant.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Your license was activated successfully.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Your license was activated successfully.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- The license activates.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>The license activates.</li>
+  </ul>
 </div>
 </div>
 
 Use hyphens to connect descriptive words before nouns.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- A multi-user license
-- The license is multi-user
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>A multi-user license</li>
+    <li>The license is multi-user</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- A multi user license
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>A multi user license</li>
+  </ul>
 </div>
 </div>
 
@@ -186,34 +218,44 @@ Note licenses can be both proper nouns and common nouns (per Product License vs.
 
 Use clear and specific dates, limits and consequences.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Your license expires on November 30, 2025.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Your license expires on November 30, 2025.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Your license will expire soon.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your license will expire soon.</li>
+  </ul>
 </div>
 </div>
 
 Use prominent and clear expiration warnings.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- First notice: Your license expires on November 30, 2025.
-- Second notice: Your license expires in 7 days.
-- Final notice: Your license expires tomorrow.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>First notice: Your license expires on November 30, 2025.</li>
+    <li>Second notice: Your license expires in 7 days.</li>
+    <li>Final notice: Your license expires tomorrow.</li>
+  </ul>
 </div>
 </div>
 
 Send timely, progressive reminders, especially for expiration and grace periods.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Heading: Your license has expired.<br/>Description: Your license expired on January 1, 2026. To continue using our application renew your subscription.<br/>Buttons: Renew now / Contact sales
-- Grace period notice: 7 days
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: Your license has expired.<br/>Description: Your license expired on January 1, 2026. To continue using our application renew your subscription.<br/>Buttons: Renew now / Contact sales</li>
+    <li>Grace period notice: 7 days</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- License expired.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>License expired.</li>
+  </ul>
 </div>
 </div>
 
@@ -221,14 +263,18 @@ Send timely, progressive reminders, especially for expiration and grace periods.
 
 Use “quantity” to refer to how many and “number” to refer to identifiers and codes.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- product number
-- serial number
-- Enter your license key
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>product number</li>
+    <li>serial number</li>
+    <li>Enter your license key</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Enter your license key quantity
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Enter your license key quantity</li>
+  </ul>
 </div>
 </div>
 
@@ -236,56 +282,76 @@ Use “quantity” to refer to how many and “number” to refer to identifiers
 
 Use “ID” for identification and tracking and “key” for activation or access.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Enter your license key.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Enter your license key.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Enter your license ID.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Enter your license ID.</li>
+  </ul>
 </div>
 </div>
 
 Use “subscription ID” when referring to the unique identifier number or code for an entire subscription (often a long number or UUID).
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Your subscription ID is 1234567890.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Your subscription ID is 1234567890.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Your subscription key is 1234567890.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your subscription key is 1234567890.</li>
+  </ul>
 </div>
 </div>
 
 Use “subscription key” when referring to a code or password required to activate or access a subscription.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Copy this subscription key to activate your subscription.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Copy this subscription key to activate your subscription.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Copy this subscription ID to activate your subscription.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Copy this subscription ID to activate your subscription.</li>
+  </ul>
 </div>
 </div>
 
 Use “license ID” or “ID” for the unique identifier of a specific license within the subscription.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Each license has its own license ID for tracking and management.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Each license has its own license ID for tracking and management.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Each license has its own license key for tracking and management.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Each license has its own license key for tracking and management.</li>
+  </ul>
 </div>
 </div>
 
 Use “license key” when talking about the code or string that unlocks or activates a specific license.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Enter your license key to activate the product.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Enter your license key to activate the product.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Enter your license ID to activate the product.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Enter your license ID to activate the product.</li>
+  </ul>
 </div>
 </div>
 
@@ -293,17 +359,21 @@ Use “license key” when talking about the code or string that unlocks or acti
 
 When licenses cannot be found, explain possible causes and provide clear actions to resolve the issue.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Heading: License not found<br/>Description: Failed to find a valid license for this product. This may happen if you’re registered under a different account, or if your license has not been activated yet.<br/>Button: Sign in with different account
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: License not found<br/>Description: Failed to find a valid license for this product. This may happen if you’re registered under a different account, or if your license has not been activated yet.<br/>Button: Sign in with different account</li>
+  </ul>
 </div>
 </div>
 
 When licenses are not available, explain how users can resolve the issue.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Heading: No licenses available<br/>Description: All 10 licenses are currently in use. Ask your administrator to assign a license to you or wait until one becomes available.<br/>Buttons: Request license / View license usage
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: No licenses available<br/>Description: All 10 licenses are currently in use. Ask your administrator to assign a license to you or wait until one becomes available.<br/>Buttons: Request license / View license usage</li>
+  </ul>
 </div>
 </div>
 
@@ -311,83 +381,105 @@ When licenses are not available, explain how users can resolve the issue.
 
 Use “add-on” to refer to additional features or modules attached to an existing product.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Add the Health package add-on for obsolescence notifications.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Add the Health package add-on for obsolescence notifications.</li>
+  </ul>
 </div>
 </div>
 
 Use “upgrade” for when users are moving to a better version of the same product.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Upgrade to the Professional edition for more features.
-- Upgrade your license from Version 2.0 to Version 3.0.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Upgrade to the Professional edition for more features.</li>
+    <li>Upgrade your license from Version 2.0 to Version 3.0.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Add the next edition as an add-on.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Add the next edition as an add-on.</li>
+  </ul>
 </div>
 </div>
 
 Use “requirement” to refer to what a user needs to run the software.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- License requirements: Active subscription and internet connection.
-- This feature requires an active maintenance agreement.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>License requirements: Active subscription and internet connection.</li>
+    <li>This feature requires an active maintenance agreement.</li>
+  </ul>
 </div>
 </div>
 
 Use “entitlement” to refer to what the user is authorized to do.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Your entitlement includes 5 user licenses.
-- This feature is not included in your current entitlement.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Your entitlement includes 5 user licenses.</li>
+    <li>This feature is not included in your current entitlement.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Your requirement includes 5 user licenses.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your requirement includes 5 user licenses.</li>
+  </ul>
 </div>
 </div>
 
 Use the standard term “activate” and “assign” instead of the non-standard “start”.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Activate license now.
-- Assign licenses to your team in your dashboard.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Activate license now.</li>
+    <li>Assign licenses to your team in your dashboard.</li>
+  </ul>
 </div>
 </div>
 
 Use “renew” instead of “update” for continuing subscriptions.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Renew your license in one easy step.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Renew your license in one easy step.</li>
+  </ul>
 </div>
 </div>
 
 Use “manage” instead of “edit” to administer licenses.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Manage your licenses under License management.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Manage your licenses under License management.</li>
+  </ul>
 </div>
 </div>
 
 Use “base” product to talk about a foundation product that other features build on.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- The base product includes core functionality.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>The base product includes core functionality.</li>
+  </ul>
 </div>
 </div>
 
 Use “basic” product when talking about a simplified or entry-level version of your product.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Select either our Basic, Premium or Advanced licenses.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Select either our Basic, Premium or Advanced licenses.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/logging-in-and-out.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/logging-in-and-out.md
@@ -14,250 +14,326 @@ description: 'Consistent login/logout text reduces confusion, builds trust, and 
 
 Use “log in” and “log out” as the action verbs instead of “sign in” or “sign out” for consistency.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Log out
-- Log in to get started
-- Log in with Microsoft ID
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Log out</li>
+    <li>Log in to get started</li>
+    <li>Log in with Microsoft ID</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Log off
-- Sign out
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Log off</li>
+    <li>Sign out</li>
+  </ul>
 </div>
 </div>
 
 Use “login” and “logout” as the nouns instead of “signoff” or “logoff” for consistency.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Logout
-- The login button is located on the top right corner of the screen.
-- After logout, you’ll be directed to the homepage.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Logout</li>
+    <li>The login button is located on the top right corner of the screen.</li>
+    <li>After logout, you’ll be directed to the homepage.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Logoff
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Logoff</li>
+  </ul>
 </div>
 </div>
 
 Use “create account” instead of “register” for consistency and transparency.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Create account
-- Register
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Create account</li>
+    <li>Register</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Join
-- Enroll
-- Sign up
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Join</li>
+    <li>Enroll</li>
+    <li>Sign up</li>
+  </ul>
 </div>
 </div>
 
 Provide feedback and guidance when there are unexpected errors during login.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Unexpected error during login. Open homepage and try again.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Unexpected error during login. Open homepage and try again.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- An unexpected error occurred during login.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>An unexpected error occurred during login.</li>
+  </ul>
 </div>
 </div>
 
 Provide clear actions when users need to log in again or have been logged out unexpectedly.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Session expired due to inactivity. Log in to continue working.
-- Session expired due to inactivity. Log in again to continue working.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Session expired due to inactivity. Log in to continue working.</li>
+    <li>Session expired due to inactivity. Log in again to continue working.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Your session has expired.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your session has expired.</li>
+  </ul>
 </div>
 </div>
 
 Avoid generic “refresh” or “reload” buttons, instead move users forward with concrete actions.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Failed to log in. Check your credentials and try again.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Failed to log in. Check your credentials and try again.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Login failed. Refresh page.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Login failed. Refresh page.</li>
+  </ul>
 </div>
 </div>
 
 Avoid using question prompts to make texts leaner and avoid punctuation issues.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Forgot password
-- Request new password
-- Create account
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Forgot password</li>
+    <li>Request new password</li>
+    <li>Create account</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Forgot your password?
-- Don’t have an account? Register now
-- Already have an account?
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Forgot your password?</li>
+    <li>Don’t have an account? Register now</li>
+    <li>Already have an account?</li>
+  </ul>
 </div>
 </div>
 
 Clearly explain password policy to avoid frustration or user friction.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Minimum 12 characters<br/>
-Minimum 1 uppercase letter (A-Z)<br/>
-Minimum 1 number<br/>
-Minimum 1 special character (!@#$%^&*)
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Minimum 12 characters<br/>
+    Minimum 1 uppercase letter (A-Z)<br/>
+    Minimum 1 number<br/>
+    Minimum 1 special character (!@#$%^&*)</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Ensure you meet the password criteria.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Ensure you meet the password criteria.</li>
+  </ul>
 </div>
 </div>
 
 Guide users when they add invalid input to support password creation.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Matches one of your last 3 passwords
-- Uses invalid characters
-- Missing a lower case letter
-- Contains spaces
-- Contains your username
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Matches one of your last 3 passwords</li>
+    <li>Uses invalid characters</li>
+    <li>Missing a lower case letter</li>
+    <li>Contains spaces</li>
+    <li>Contains your username</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Wrong password format
-- Invalid
-- Error
-- Try again
-- Password error code: 5467
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Wrong password format</li>
+    <li>Invalid</li>
+    <li>Error</li>
+    <li>Try again</li>
+    <li>Password error code: 5467</li>
+  </ul>
 </div>
 </div>
 
 Show real-time password strength.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Weak
-- Fair
-- Strong
-- Very strong
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Weak</li>
+    <li>Fair</li>
+    <li>Strong</li>
+    <li>Very strong</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Not strong enough
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Not strong enough</li>
+  </ul>
 </div>
 </div>
 
 Avoid using password or password-related jargon or abbreviations.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- One-time password
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>One-time password</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- OTP
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>OTP</li>
+  </ul>
 </div>
 </div>
 
 Use “change password” instead of “update password” for consistency.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Change password
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Change password</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Update password
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Update password</li>
+  </ul>
 </div>
 </div>
 
 Use “email” or “email address” as both are acceptable.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Enter a valid email.
-- Enter a valid email address.
-- Enter your email below to receive a password reset link.
-- Incorrect email or password. Check your details and try again.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Enter a valid email.</li>
+    <li>Enter a valid email address.</li>
+    <li>Enter your email below to receive a password reset link.</li>
+    <li>Incorrect email or password. Check your details and try again.</li>
+  </ul>
 </div>
 </div>
 
 Use * consistently to indicate [required fields](../../../components/forms-field/code.mdx#required-indicator) depending on space limitations.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- First name*
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>First name*</li>
+  </ul>
 </div>
 </div>
 
 Use “verify” and “verification” when users need to authenticate with their credentials.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Verification code
-- Verify your account
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Verification code</li>
+    <li>Verify your account</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Validate
-- Confirm
-- Authenticate
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Validate</li>
+    <li>Confirm</li>
+    <li>Authenticate</li>
+  </ul>
 </div>
 </div>
 
 Use “first name” and “last name” instead of “surname”, “given name” or “Christian name”.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- First name / Last name
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>First name / Last name</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Given name / Surname
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Given name / Surname</li>
+  </ul>
 </div>
 </div>
 
 Use “ZIP code” (US English) instead of “postcode” (UK) as we use the American English variation.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Enter ZIP code
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Enter ZIP code</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Enter postcode
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Enter postcode</li>
+  </ul>
 </div>
 </div>
 
 Use generic password error messages to avoid leaking information.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Failed to log in. Incorrect username or password.
-- Failed to log in. Incorrect user email or password.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Failed to log in. Incorrect username or password.</li>
+    <li>Failed to log in. Incorrect user email or password.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- 1 number was incorrect on this password. Try again.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>1 number was incorrect on this password. Try again.</li>
+  </ul>
 </div>
 </div>
 
 Use generic password recovery messages to avoid leaking information.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- If that email address is in our database, we will send you an email to reset your password.
-- If your email address is registered, you’ll receive a password reset email.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>If that email address is in our database, we will send you an email to reset your password.</li>
+    <li>If your email address is registered, you’ll receive a password reset email.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Account is locked.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Account is locked.</li>
+  </ul>
 </div>
 </div>
 
 Use specific authentication terms and use them consistently within workflows to avoid confusion.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Code / Authentication code / Code verified
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Code / Authentication code / Code verified</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Code / Token / Passcode / Digits
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Code / Token / Passcode / Digits</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/onboarding.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/onboarding.md
@@ -22,102 +22,128 @@ We follow this three-step approach when writing our onboarding messages.
 
 Welcome users in the onboarding component only once with a friendly yet professional tone.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Welcome to [application name]
-- Welcome [user name] to [application name]
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Welcome to [application name]</li>
+    <li>Welcome [user name] to [application name]</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Welcome again to [application name]
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Welcome again to [application name]</li>
+  </ul>
 </div>
 </div>
 
 Use a friendly, professional tone that’s engaging and informative but not casual or informal.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Get started
-- Getting started
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Get started</li>
+    <li>Getting started</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Hey there! Let’s dive in and get you rolling! 🚀
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Hey there! Let’s dive in and get you rolling! 🚀</li>
+  </ul>
 </div>
 </div>
 
 Avoid using marketing or selling wording, instead address users as a partner and expert.
 
-<div className="dos-and-donts" markdown>
-<div className="donts" markdown>
-- Connecting your mobile device is a piece of cake with our Asset Manager.
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Connecting your mobile device is a piece of cake with our Asset Manager.</li>
+  </ul>
 </div>
 </div>
 
 Break onboarding into small, manageable steps with bullet points, pagination or short paragraphs.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Set up your notifications:<br/>
-	&nbsp;&nbsp;&bull; Select the notifications you want<br/>
-	&nbsp;&nbsp;&bull; Set quiet hours to avoid interruptions
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Set up your notifications:<br/>
+    &nbsp;&nbsp;&bull; Select the notifications you want<br/>
+    &nbsp;&nbsp;&bull; Set quiet hours to avoid interruptions</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Getting started with smart notifications. You can now choose what types of alerts you want, set quiet hours, and customize how you receive notifications so you’re not overwhelmed.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Getting started with smart notifications. You can now choose what types of alerts you want, set quiet hours, and customize how you receive notifications so you’re not overwhelmed.</li>
+  </ul>
 </div>
 </div>
 
 Use verbs for call-to-actions, providing concrete actions or onboarding steps.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Get started
-- Start now
-- Start tour
-- Learn more
-- Register
-- Create account
-- Explore the app
-- Onboard devices
-- Learn how to onboard assets
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Get started</li>
+    <li>Start now</li>
+    <li>Start tour</li>
+    <li>Learn more</li>
+    <li>Register</li>
+    <li>Create account</li>
+    <li>Explore the app</li>
+    <li>Onboard devices</li>
+    <li>Learn how to onboard assets</li>
+  </ul>
 </div>
 </div>
 
 Avoid generic call-to-actions when possible to enhance transparency and build confidence.
 
-<div className="dos-and-donts" markdown>
-<div className="donts" markdown>
-- OK
-- Click here
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>OK</li>
+    <li>Click here</li>
+  </ul>
 </div>
 </div>
 
 Use clear (but not catastrophic) wording to highlight important points for users to remember.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Important: Always log out using your profile. Do not simply close the app.
-- Make sure you “Save all” before leaving workflows to save your data.
-- We recommend creating a backup of your dashboard to avoid risk of data loss.
-- Note: You can always find this tour in the “About” tab.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Important: Always log out using your profile. Do not simply close the app.</li>
+    <li>Make sure you “Save all” before leaving workflows to save your data.</li>
+    <li>We recommend creating a backup of your dashboard to avoid risk of data loss.</li>
+    <li>Note: You can always find this tour in the “About” tab.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Failure to save your changes will result in permanent loss of your data.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Failure to save your changes will result in permanent loss of your data.</li>
+  </ul>
 </div>
 </div>
 
 Provide a clear way for users to dismiss or postpone onboarding without confusion.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Close
-- Skip
-- Skip and don’t show again
-- Remind me at next login
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Close</li>
+    <li>Skip</li>
+    <li>Skip and don’t show again</li>
+    <li>Remind me at next login</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Confirm
-- Proceed
-- Continue
-- Maybe later
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Confirm</li>
+    <li>Proceed</li>
+    <li>Continue</li>
+    <li>Maybe later</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/search-and-filter.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/search-and-filter.md
@@ -14,28 +14,36 @@ description: 'Industrial applications handle large datasets where users need to 
 
 Use “Search” as the primary action label and avoid vague, long or technical alternatives.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Search
-- Search equipment
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Search</li>
+    <li>Search equipment</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Go
-- Find
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Go</li>
+    <li>Find</li>
+  </ul>
 </div>
 </div>
 
 Use clear, specific placeholder text that indicates what users can search for in the current context.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Search by equipment ID, serial number or location…
-- Search parts by name, part number or category…
-- Search…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Search by equipment ID, serial number or location…</li>
+    <li>Search parts by name, part number or category…</li>
+    <li>Search…</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Enter search
-- Type here 
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Enter search</li>
+    <li>Type here</li>
+  </ul>
 </div>
 </div>
 
@@ -43,74 +51,96 @@ Use clear, specific placeholder text that indicates what users can search for in
 
 Use “Advanced search” to provide access to additional search options.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Advanced search 
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Advanced search</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Additional 
-- Detailed search
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Additional</li>
+    <li>Detailed search</li>
+  </ul>
 </div>
 </div>
 
 Use “Filter by” followed by the specific attribute to make filtering options immediately clear.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Filter by machine type
-- Filter by date range
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Filter by machine type</li>
+    <li>Filter by date range</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Filters
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Filters</li>
+  </ul>
 </div>
 </div>
 
 Use prominent, one-click filter options for the most common filtering needs when possible.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Quick filters: Active | Needs maintenance | Critical
-- Show: All | Active only | Inactive only
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Quick filters: Active | Needs maintenance | Critical</li>
+    <li>Show: All | Active only | Inactive only</li>
+  </ul>
 </div>
 </div>
 
 Use “Apply filters” as the primary action label.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Apply filters
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Apply filters</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Filter
-- Set filters
-- Find
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Filter</li>
+    <li>Set filters</li>
+    <li>Find</li>
+  </ul>
 </div>
 </div>
 
 Use “Clear" or “Clear filters” to remove all active filters at once.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Clear 
-- Clear filters
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Clear</li>
+    <li>Clear filters</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Remove all
-- Reset
-- Clear
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Remove all</li>
+    <li>Reset</li>
+    <li>Clear</li>
+  </ul>
 </div>
 </div>
 
 Indicate whether filters will persist across sessions.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Filters remain active until you clear them.
-- Filters reset when you log out.
-- Filters will be saved for your next session. 
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Filters remain active until you clear them.</li>
+    <li>Filters reset when you log out.</li>
+    <li>Filters will be saved for your next session.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Filters may persist. 
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Filters may persist.</li>
+  </ul>
 </div>
 </div>
 
@@ -118,56 +148,72 @@ Indicate whether filters will persist across sessions.
 
 Use clear wording when there are no results found. 
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- No results.
-- No results found for “valve”.
-- No matching equipment found. 
-- No results. Refine search.  
-- No results. Try adjusting your filters and search terms.  
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>No results.</li>
+    <li>No results found for “valve”.</li>
+    <li>No matching equipment found.</li>
+    <li>No results. Refine search.</li>
+    <li>No results. Try adjusting your filters and search terms.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Failed 
-- Nothing found. 
-- Empty. 
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Failed</li>
+    <li>Nothing found.</li>
+    <li>Empty.</li>
+  </ul>
 </div>
 </div>
 
 Use specific numbers and clear language to show how many results were found.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Showing 47 of 230 machines
-- 12 results found for “pressure valve”
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Showing 47 of 230 machines</li>
+    <li>12 results found for “pressure valve”</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- 47 items
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>47 items</li>
+  </ul>
 </div>
 </div>
 
 Include both total page count and current position when using pagination.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Page 2 of 15
-- Showing 1-50 of 730 results
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Page 2 of 15</li>
+    <li>Showing 1-50 of 730 results</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Next
-- Previous
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Next</li>
+    <li>Previous</li>
+  </ul>
 </div>
 </div>
 
 Use “Display X results per page” or “Results per page” to allow users to adjust display quantity.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Results per page: 50
-- Display 50 results per page
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Results per page: 50</li>
+    <li>Display 50 results per page</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Display: 50
-- 50
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Display: 50</li>
+    <li>50</li>
+  </ul>
 </div>
 </div>
 
@@ -175,39 +221,51 @@ Use “Display X results per page” or “Results per page” to allow users to
 
 Use “Narrow search” or “Adjust filters” when users can narrow existing search results.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Narrow search
-- Adjust filters
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Narrow search</li>
+    <li>Adjust filters</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Refine results 
-- Modify results
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Refine results</li>
+    <li>Modify results</li>
+  </ul>
 </div>
 </div>
 
 Use “Expand search” when users can broaden their search. 
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Expand search to all locations
-- Show more results 
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Expand search to all locations</li>
+    <li>Show more results</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Broaden results 
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Broaden results</li>
+  </ul>
 </div>
 </div>
 
 Use “Sort by” followed by the sorting criterion to make ordering options clear.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Sort by: Date (newest to oldest)
-- Sort by: Equipment name (a-z)
-- Sort by: Priority (high to low)
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Sort by: Date (newest to oldest)</li>
+    <li>Sort by: Equipment name (a-z)</li>
+    <li>Sort by: Priority (high to low)</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Order by
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Order by</li>
+  </ul>
 </div>
 </div>
 
@@ -215,43 +273,55 @@ Use “Sort by” followed by the sorting criterion to make ordering options cle
 
 Use actionable language when no results are found to guide users forward.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Nothing found. Refine search.
-- No alarms found in selected period. Expand period. 
-- No equipment found. Adjust your filters or search terms.
-- No alarms found in selected time range. Try expanding the date range. 
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Nothing found. Refine search.</li>
+    <li>No alarms found in selected period. Expand period.</li>
+    <li>No equipment found. Adjust your filters or search terms.</li>
+    <li>No alarms found in selected time range. Try expanding the date range.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- 0 results
-- Nothing found
-- Your search returned no results
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>0 results</li>
+    <li>Nothing found</li>
+    <li>Your search returned no results</li>
+  </ul>
 </div>
 </div>
 
 Use “Did you mean” or “Suggestions” to help users correct spelling errors or find related terms.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Did you mean “turbine”?
-- No results for “pymp”. Did you mean “pump”?
-- Suggestions: motor, engine, generator
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Did you mean “turbine”?</li>
+    <li>No results for “pymp”. Did you mean “pump”?</li>
+    <li>Suggestions: motor, engine, generator</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Try: turbine
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Try: turbine</li>
+  </ul>
 </div>
 </div>
 
 Use specific, actionable error messages when search operations fail.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Unable to complete search. Check your connection and try again.
-- Search timeout. Narrow your search criteria.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Unable to complete search. Check your connection and try again.</li>
+    <li>Search timeout. Narrow your search criteria.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Search failed.
-- Something went wrong.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Search failed.</li>
+    <li>Something went wrong.</li>
+  </ul>
 </div>
 </div>
 
@@ -259,27 +329,35 @@ Use specific, actionable error messages when search operations fail.
 
 Use “Recent searches” or “Search history” to display previously entered search terms.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Recent searches
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Recent searches</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Previous
-- History
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Previous</li>
+    <li>History</li>
+  </ul>
 </div>
 </div>
 
 Use “Save search” or “Save search criteria” to allow users to store frequently used searches.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Save search.
-- Save search criteria as “Active pumps in Building A”
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Save search.</li>
+    <li>Save search criteria as “Active pumps in Building A”</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Save
-- Store
-- Remember search
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Save</li>
+    <li>Store</li>
+    <li>Remember search</li>
+  </ul>
 </div>
 </div>
 
@@ -287,38 +365,48 @@ Use “Save search” or “Save search criteria” to allow users to store freq
 
 Use clear labels for logical operators (AND, OR, NOT) that explain how conditions combine.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Status: Active AND Location: Munich
-- Type: Pump OR Type: Compressor
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Status: Active AND Location: Munich</li>
+    <li>Type: Pump OR Type: Compressor</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Active & Munich
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Active & Munich</li>
+  </ul>
 </div>
 </div>
 
 Provide templates for common conditional searches.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- <div>Template: Active equipment needing maintenance <br/>
-Status: Active AND Maintenance: Due</div>
-- <div>Template: High priority work orders for team A <br/>
-Priority: High AND Assigned team: Team A</div>
-- <div>Template: Temperature readings <br/>
-Sensor: Temperature AND Value: &gt; 100</div>
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li><div>Template: Active equipment needing maintenance <br/>
+    Status: Active AND Maintenance: Due</div></li>
+    <li><div>Template: High priority work orders for team A <br/>
+    Priority: High AND Assigned team: Team A</div></li>
+    <li><div>Template: Temperature readings <br/>
+    Sensor: Temperature AND Value: &gt; 100</div></li>
+  </ul>
 </div>
 </div>
 
 Tell users when conditions create impossible or contradictory queries.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Status cannot be both Active AND Inactive. Refine filter.
-- This combination will return no results. Refine filter.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Status cannot be both Active AND Inactive. Refine filter.</li>
+    <li>This combination will return no results. Refine filter.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Invalid search
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Invalid search</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/search-and-filter.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/search-and-filter.md
@@ -412,10 +412,20 @@ Tell users when conditions create impossible or contradictory queries.
 
 ## Dos and Don’ts
 
-- Do provide simple examples or templates for common conditional searches to help users get started
-- Do offer actionable next steps and helpful suggestions when searches fail or return no results
-- Don’t provide unhelpful “Try again” recommendations that provide no guidance on what to do next
-- Don’t use generic or vague labels like “Go”, “Find” or “Error” 
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do provide simple examples or templates for common conditional searches to help users get started</li>
+      <li>Do offer actionable next steps and helpful suggestions when searches fail or return no results</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t provide unhelpful “Try again” recommendations that provide no guidance on what to do next</li>
+      <li>Don’t use generic or vague labels like “Go”, “Find” or “Error”</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/ui-terminology.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/ui-terminology.md
@@ -244,10 +244,20 @@ Many actions come in natural pairs or opposites. Using the right pairs help user
 
 ## Dos and Don’ts
 
-- Do maintain the same terms for the same actions across all screens
-- Do use specific and standardized component names
-- Do consider the user environment, e.g. mobile, desktop, touchscreen
-- Don’t use generic, invented or vague terms where terminology already exists
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do maintain the same terms for the same actions across all screens</li>
+      <li>Do use specific and standardized component names</li>
+      <li>Do consider the user environment, e.g. mobile, desktop, touchscreen</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use generic, invented or vague terms where terminology already exists</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/ui-terminology.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/ui-terminology.md
@@ -14,29 +14,35 @@ description: 'Using well-defined terms help users understand actions, navigate s
 
 Always consider the difference between user actions within a desktop environment (based on mouse or keyboard usage) and mobile devices based on touch gestures.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- click (desktop)
-- tap (mobile device)
-- select (when not sure if desktop or mobile)
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>click (desktop)</li>
+    <li>tap (mobile device)</li>
+    <li>select (when not sure if desktop or mobile)</li>
+  </ul>
 </div>
 </div>
 
 Use clear and precise terms that leave no room for misunderstandings.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- delete (if you want to erase data, e.g. a file)
-- remove (if you want to take data away, e.g. permissions)
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>delete (if you want to erase data, e.g. a file)</li>
+    <li>remove (if you want to take data away, e.g. permissions)</li>
+  </ul>
 </div>
 </div>
 
 Use “select” for multi-platform applications where the input method varies (tap, click, etc.).
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Select the checkbox to enable notifications.
-- Select and hold the Shift key to select multiple items.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Select the checkbox to enable notifications.</li>
+    <li>Select and hold the Shift key to select multiple items.</li>
+  </ul>
 </div>
 </div>
 
@@ -52,12 +58,16 @@ This section provides clear definitions for the most frequently used mouse-relat
 - right-click
 - middle-click (scroll wheel)
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- click
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>click</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- press
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>press</li>
+  </ul>
 </div>
 </div>
 
@@ -68,12 +78,16 @@ This section provides clear definitions for the most frequently used mouse-relat
 - hover
 - scroll
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- hover
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>hover</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- mouse over
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>mouse over</li>
+  </ul>
 </div>
 </div>
 
@@ -111,32 +125,40 @@ As touchscreen interfaces rely on direct finger interaction, this section covers
 
 Use "press" when referring to the physical action of pressing a key.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Press Enter to confirm
-- Press Spacebar to play or pause
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Press Enter to confirm</li>
+    <li>Press Spacebar to play or pause</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Hit Enter
-- Strike Enter
-- Depress Enter
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Hit Enter</li>
+    <li>Strike Enter</li>
+    <li>Depress Enter</li>
+  </ul>
 </div>
 </div>
 
 Capitalize special keys and directions.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Enter / Tab / Shift / Ctrl / Alt
-- Up Arrow / Down Arrow / Left Arrow / Right Arrow
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Enter / Tab / Shift / Ctrl / Alt</li>
+    <li>Up Arrow / Down Arrow / Left Arrow / Right Arrow</li>
+  </ul>
 </div>
 </div>
 
 Use "type" when asking users to enter text.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Type admin in the username field.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Type admin in the username field.</li>
+  </ul>
 </div>
 </div>
 
@@ -144,30 +166,38 @@ Use "type" when asking users to enter text.
 
 Use standardized and consistent terminology to describe UI components and input elements.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- checkbox
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>checkbox</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- box
-- option box
-- selection box
-- tick box
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>box</li>
+    <li>option box</li>
+    <li>selection box</li>
+    <li>tick box</li>
+  </ul>
 </div>
 </div>
 
 Avoid mixing terms within the same products and portfolios.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- To enable automatic updates, select the checkbox to activate Auto update.
-- Click this image
-- The link opens in a new window.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>To enable automatic updates, select the checkbox to activate Auto update.</li>
+    <li>Click this image</li>
+    <li>The link opens in a new window.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- To enable automatic updates, select the box to activate Auto update.
-- Click this picture
-- The link opens in a new browser.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>To enable automatic updates, select the box to activate Auto update.</li>
+    <li>Click this picture</li>
+    <li>The link opens in a new browser.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/user-management.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/user-management.md
@@ -364,11 +364,21 @@ Avoid using “revoke” with people and users as direct objects.
 
 ## Dos and Don’ts
 
-- Do ensure role behaviors are transparent and easy to understand
-- Do use clear, descriptive role names that reflect user responsibilities
-- Do group related permissions logically within roles
-- Don’t create excessive amounts of roles because this causes confusion
-- Don’t create overlapping roles with unclear differences
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do ensure role behaviors are transparent and easy to understand</li>
+      <li>Do use clear, descriptive role names that reflect user responsibilities</li>
+      <li>Do group related permissions logically within roles</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t create excessive amounts of roles because this causes confusion</li>
+      <li>Don’t create overlapping roles with unclear differences</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/user-management.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/user-management.md
@@ -28,138 +28,182 @@ Use “permissions” instead of “right” and “privilege” as these are be
 
 Write user roles in short, clear and descriptive terms and give users access to role descriptions.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Line operator
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Line operator</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Basic user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Basic user</li>
+  </ul>
 </div>
 </div>
 
 Use role names consistently within workflows and across the whole product.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Device administrator / Device administrator / Device administrator
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Device administrator / Device administrator / Device administrator</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Device Admin / Asset Admins / Administrator / Device Manager / Officer for devices
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Device Admin / Asset Admins / Administrator / Device Manager / Officer for devices</li>
+  </ul>
 </div>
 </div>
 
 Focus on personas instead of generic and unclear titles when creating roles for your product.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Line operator
-- Plant operator
-- Service engineer
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Line operator</li>
+    <li>Plant operator</li>
+    <li>Service engineer</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Technician
-- Team lead
-- Expert user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Technician</li>
+    <li>Team lead</li>
+    <li>Expert user</li>
+  </ul>
 </div>
 </div>
 
 Avoid mixing location with function when creating roles for your product.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- User
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>User</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- External user
-- Local user
-- International user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>External user</li>
+    <li>Local user</li>
+    <li>International user</li>
+  </ul>
 </div>
 </div>
 
 Avoid creating vague user roles without a clear persona or scope that can be misunderstood.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Production report creator
-- Quality report reviewer
-- Batch approver (review and release)
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Production report creator</li>
+    <li>Quality report reviewer</li>
+    <li>Batch approver (review and release)</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Read-only user
-- Write-only user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Read-only user</li>
+    <li>Write-only user</li>
+  </ul>
 </div>
 </div>
 
 Use “read only” as a specific role permission, not a unique role name.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- External consultant (read-only)
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>External consultant (read-only)</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Read-only user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Read-only user</li>
+  </ul>
 </div>
 </div>
 
 Avoid easily misunderstood permissions such as “view”, be specific about what users can do.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- record / log / configure / override
-- adjust / review / modify / correct
-- monitor / review / inspect
-- track / display / observe
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>record / log / configure / override</li>
+    <li>adjust / review / modify / correct</li>
+    <li>monitor / review / inspect</li>
+    <li>track / display / observe</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- write
-- edit
-- read-only
-- view
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>write</li>
+    <li>edit</li>
+    <li>read-only</li>
+    <li>view</li>
+  </ul>
 </div>
 </div>
 
 Use sentence case for all user roles.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Service engineer
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Service engineer</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Service Engineer
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Service Engineer</li>
+  </ul>
 </div>
 </div>
 
 Avoid jargon or internal terms, instead use language everyone understands.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Plant manager
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Plant manager</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Top tier
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Top tier</li>
+  </ul>
 </div>
 </div>
 
 Keep role names short, preferably not more than three words.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Safety incident investigator
-- Shift handover reporter
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Safety incident investigator</li>
+    <li>Shift handover reporter</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Gateway and portal maintenance manager for Plant 3 and 5 (read-only permissions)
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Gateway and portal maintenance manager for Plant 3 and 5 (read-only permissions)</li>
+  </ul>
 </div>
 </div>
 
 Avoid using functions or features as roles or permissions, instead focus on persona and tasks.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Shift supervisor – Production floor
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Shift supervisor – Production floor</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Dashboard user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Dashboard user</li>
+  </ul>
 </div>
 </div>
 
@@ -199,94 +243,122 @@ Many user management words often appear together in familiar, expected combinati
 
 Avoid using “deny” and “disapprove” with “user” as opposites to “approve”.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Reject access request
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Reject access request</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Admin denied user
-- Disapprove user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Admin denied user</li>
+    <li>Disapprove user</li>
+  </ul>
 </div>
 </div>
 
 Avoid using “deauthenticate” as the opposite of authenticate.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Log out
-- End session
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Log out</li>
+    <li>End session</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Deauthenticate
-- Click to deauthenticate
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Deauthenticate</li>
+    <li>Click to deauthenticate</li>
+  </ul>
 </div>
 </div>
 
 Avoid using “grant” with “permissions” in casual UI contexts as this has become outdated.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Assign permissions to user
-- Give user access to reports
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Assign permissions to user</li>
+    <li>Give user access to reports</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Grant permissions to user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Grant permissions to user</li>
+  </ul>
 </div>
 </div>
 
 Avoid using “read” for viewing UI elements like profiles, permissions and roles.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- View user profile
-- View role details
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>View user profile</li>
+    <li>View role details</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Read user profile
-- Read permissions
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Read user profile</li>
+    <li>Read permissions</li>
+  </ul>
 </div>
 </div>
 
 Avoid using “write” for editing or modifying UI elements.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Edit permissions
-- Modify settings
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Edit permissions</li>
+    <li>Modify settings</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Write permissions
-- Write role details
-- Write to database
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Write permissions</li>
+    <li>Write role details</li>
+    <li>Write to database</li>
+  </ul>
 </div>
 </div>
 
 Avoid using “delete” for simple removals; use “delete” only for permanent erasure. 
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Unassign
-- Remove user from team
-- Remove role from user
-- Delete user account (permanent)
-- Delete file (permanent)
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Unassign</li>
+    <li>Remove user from team</li>
+    <li>Remove role from user</li>
+    <li>Delete user account (permanent)</li>
+    <li>Delete file (permanent)</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Delete user from team
-- Delete role from user
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Delete user from team</li>
+    <li>Delete role from user</li>
+  </ul>
 </div>
 </div>
 
 Avoid using “revoke” with people and users as direct objects.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Revoke all permissions
-- Revoke API key
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Revoke all permissions</li>
+    <li>Revoke API key</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Revoke user
-- Revoke the employee
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Revoke user</li>
+    <li>Revoke the employee</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/menu-functions-and-ui-labels/whats-new-announcements.md
+++ b/docs/guidelines/language/menu-functions-and-ui-labels/whats-new-announcements.md
@@ -22,84 +22,110 @@ We follow this three-step approach when creating our updates. They explain what�
 
 Use the wording “What’s new…” for the heading without a question mark (?) or period.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- What’s new in October
-- What’s new in Version 3.2
-- What’s new this month
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>What’s new in October</li>
+    <li>What’s new in Version 3.2</li>
+    <li>What’s new this month</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- What’s new this month?
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>What’s new this month?</li>
+  </ul>
 </div>
 </div>
 Use a contraction in the heading, i.e. “What’s” not “What is”.
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- What’s new in October
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>What’s new in October</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- What is new in October
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>What is new in October</li>
+  </ul>
 </div>
 </div>
 
 Use paragraphs or bullet points to present or highlight one point at a time instead of italics or bold.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- What’s new in the dashboard<br/>
-&nbsp;&nbsp;&bull; Edit with new filter options.<br/>
-&nbsp;&nbsp;&bull; Set up zones to itemize your assets.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>What’s new in the dashboard<br/>
+    &nbsp;&nbsp;&bull; Edit with new filter options.<br/>
+    &nbsp;&nbsp;&bull; Set up zones to itemize your assets.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- What’s new in the dashboard. Now includes customizable widgets, allowing you to tailor your view to your specific needs, new ways to edit your dashboards by moving or adjusting filters to help you with your day, and zones for dashboards such as by plant or groups to itemize your assets more easily.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>What’s new in the dashboard. Now includes customizable widgets, allowing you to tailor your view to your specific needs, new ways to edit your dashboards by moving or adjusting filters to help you with your day, and zones for dashboards such as by plant or groups to itemize your assets more easily.</li>
+  </ul>
 </div>
 </div>
 
 Use a personal and engaging tone without being too informal (avoid emojis or slang).
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- With this new version we bring you new features and improvements to enhance your experience.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>With this new version we bring you new features and improvements to enhance your experience.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Yo fam, we’ve been grinding to drop some lit upgrades to level up your vibe! 🚀✨
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Yo fam, we’ve been grinding to drop some lit upgrades to level up your vibe! 🚀✨</li>
+  </ul>
 </div>
 </div>
 
 Provide a clear way for users to dismiss announcements without confusion.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Close
-- Skip
-- Skip and don’t show again
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Close</li>
+    <li>Skip</li>
+    <li>Skip and don’t show again</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Confirm
-- Proceed
-- Continue
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Confirm</li>
+    <li>Proceed</li>
+    <li>Continue</li>
+  </ul>
 </div>
 </div>
 
 Provide a clear way for users to postpone announcements.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- Not now
-- Remind me at next login
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Not now</li>
+    <li>Remind me at next login</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Maybe later
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Maybe later</li>
+  </ul>
 </div>
 </div>
 
 Avoid technical, negative or wordy dismiss actions.
 
-<div className="dos-and-donts" markdown>
-<div className="donts" markdown>
-- Terminate dialog
-- No, I don’t want to improve my workflow
-- I confirm I understand this announcement and wish to close this notification
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Terminate dialog</li>
+    <li>No, I don’t want to improve my workflow</li>
+    <li>I confirm I understand this announcement and wish to close this notification</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/messaging/empty-state-messages.mdx
+++ b/docs/guidelines/language/messaging/empty-state-messages.mdx
@@ -20,53 +20,65 @@ We follow this three-step approach when creating our empty-state messages. They 
 
 Use the template when the error stops users moving forward.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - <div>Heading: No zones added<br/>
-    Description: Add zones to your profile to see them listed here.<br/>
-    Button: Add zones</div>
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li><div>Heading: No zones added<br/>
+      Description: Add zones to your profile to see them listed here.<br/>
+      Button: Add zones</div></li>
+    </ul>
   </div>
 
-  <div className="donts" markdown="true">
-    - <div>Heading: No zones created<br/>
-    Description: Add region from your dashboard.<br/>
-    Button: Make sectors</div>
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li><div>Heading: No zones created<br/>
+      Description: Add region from your dashboard.<br/>
+      Button: Make sectors</div></li>
+    </ul>
   </div>
 </div>
 
 Use clear action verbs to show users how to fill the empty state.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - <div>Heading: No users added <br />
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li><div>Heading: No users added <br />
       Description: Add users in User management.<br />
-      Button: Open User management</div>
-
+      Button: Open User management</div></li>
+    </ul>
   </div>
 </div>
 
 Use neutral framing of the empty state and avoid making it seem like a user failure.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- No users added
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>No users added</li>
+  </ul>
 </div>
 
-<div className="donts" markdown="true">
-- You haven’t added any of your users
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>You haven’t added any of your users</li>
+  </ul>
 </div>
 </div>
 
 Avoid “yet” or other expectation-related terms in headings.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Heading: No users added
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: No users added</li>
+  </ul>
 </div>
 
-<div className="donts" markdown="true">
-- Heading: No users added yet
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Heading: No users added yet</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/messaging/empty-state-messages.mdx
+++ b/docs/guidelines/language/messaging/empty-state-messages.mdx
@@ -84,10 +84,20 @@ Avoid “yet” or other expectation-related terms in headings.
 
 ## Dos and Don’ts
 
-- Do make all messages consistent in terms of grammar and punctuation
-- Do make sure users understand the space is not an error or a bug
-- Do provide an option to fill the empty space with a button or link
-- Don’t overcommunicate about the function of the empty state
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do make all messages consistent in terms of grammar and punctuation</li>
+      <li>Do make sure users understand the space is not an error or a bug</li>
+      <li>Do provide an option to fill the empty space with a button or link</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t overcommunicate about the function of the empty state</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/error-messages.mdx
+++ b/docs/guidelines/language/messaging/error-messages.mdx
@@ -233,11 +233,11 @@ Avoid overpromising solutions to errors unless the team is working on the proble
 
 ## Dos and Don’ts
 
-* Do make all messages consistent in terms of grammar and punctuation
-* Do take the blame when the error originates from your app or product
-* Do give users a reversible solution whenever possible
-* Don’t panic your users with dramatic or urgent language
-* Don’t use all upper case characters
+- Do make all messages consistent in terms of grammar and punctuation
+- Do take the blame when the error originates from your app or product
+- Do give users a reversible solution whenever possible
+- Don’t panic your users with dramatic or urgent language
+- Don’t use all upper case characters
 
 
 ## Related

--- a/docs/guidelines/language/messaging/error-messages.mdx
+++ b/docs/guidelines/language/messaging/error-messages.mdx
@@ -27,157 +27,205 @@ Although not every error message in a product requires all three steps, aim for 
 
 Use the template when the error stops users moving forward.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Heading: No data received<br/>
-Description: Unable to receive data as sensor is inactive.<br/>
-Instructions: Check sensor / Open sensor management
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Heading: No data received<br/>
+     Description: Unable to receive data as sensor is inactive.<br/>
+     Instructions: Check sensor / Open sensor management</li>
+   </ul>
  </div>
 </div>
 
 Avoid generic error messages or codes, instead provide specific data, value and solutions.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Failed to export data due to a connection error.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Failed to export data due to a connection error.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Something happened.
-- An error occurred.
-- Error 172.00046ERR
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Something happened.</li>
+    <li>An error occurred.</li>
+    <li>Error 172.00046ERR</li>
+  </ul>
 </div>
 </div>
 
 Give clear reasons for input validation errors to ease user frustration.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Value out of range. Enter a number between 1 and 100.
-- Number between 1 and 100 required.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Value out of range. Enter a number between 1 and 100.</li>
+    <li>Number between 1 and 100 required.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Invalid value.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Invalid value.</li>
+  </ul>
 </div>
 </div>
 
 Avoid repeating your message in both the title and description.
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Bad request: Sorry, we could not process the request. Please check and try again.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Bad request: Sorry, we could not process the request. Please check and try again.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-- Bad request. Sorry, bad request.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Bad request. Sorry, bad request.</li>
+   </ul>
  </div>
 </div>
 
 Avoid blaming the user with “you” and “your” and use passive voice as an exception.
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Device could not be deleted.
-- Failed to delete device.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Device could not be deleted.</li>
+    <li>Failed to delete device.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- You have failed to delete the device.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>You have failed to delete the device.</li>
+  </ul>
 </div>
 </div>
 
 
 Provide specific and clear solutions to avoid making assumptions about user knowledge.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Unsupported file type. Upload supported file types: .pdf and .docx.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Unsupported file type. Upload supported file types: .pdf and .docx.</li>
+   </ul>
  </div>
 
- <div className="donts" markdown="true">
-- Unsupported file type. Upload the supported and correct file type.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Unsupported file type. Upload the supported and correct file type.</li>
+   </ul>
  </div>
 </div>
 
 
 If the error is our responsibility and fault, use authentic and transparent apologies.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- We’ve moved this page. Please check the changelog for the new location.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>We’ve moved this page. Please check the changelog for the new location.</li>
+   </ul>
  </div>
 
- <div className="donts" markdown="true">
-- Sorry you entered the wrong address.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Sorry you entered the wrong address.</li>
+   </ul>
  </div>
 </div>
 
 Use “please” only for extra or unexpected user actions that correct system-caused disruptions.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Heading: Page Not Found<br/>
-Description: We could not find what you were looking for.<br/>
-Instruction: Please contact the owner of the site that linked you to the original URL and let them know their link is broken.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Heading: Page Not Found<br/>
+     Description: We could not find what you were looking for.<br/>
+     Instruction: Please contact the owner of the site that linked you to the original URL and let them know their link is broken.</li>
+   </ul>
  </div>
 </div>
 
 Show urgency with wording, e.g. “immediately” if there are consequences from ignoring the error.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Update your software version immediately to avoid losing data.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Update your software version immediately to avoid losing data.</li>
+   </ul>
  </div>
 </div>
 
 Use positive framing and avoid negative and alarming words like “wrong” and “catastrophic”.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Value out of range. Enter a number between 1 and 100.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Value out of range. Enter a number between 1 and 100.</li>
+   </ul>
  </div>
 
- <div className="donts" markdown="true">
-- Wrong number.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Wrong number.</li>
+   </ul>
  </div>
 </div>
 
 Use softening words, e.g. unfortunately and avoid negative contractions (“do not” instead of “don’t”).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Unfortunately, you cannot open this page.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Unfortunately, you cannot open this page.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- You don't have access.
-- You can't open this page.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>You don't have access.</li>
+    <li>You can't open this page.</li>
+  </ul>
 </div>
 </div>
 
 Be honest and transparent when you cannot explain the error or how to move the user forward.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Something went wrong and we couldn't complete your request. Try again later.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Something went wrong and we couldn't complete your request. Try again later.</li>
+   </ul>
  </div>
 
- <div className="donts" markdown="true">
-- Operation stopped for unknown reason.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Operation stopped for unknown reason.</li>
+   </ul>
  </div>
 </div>
 
 Avoid generic wording telling users to contact their admin or support as this is unhelpful.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Open the chat window and paste the error into the input field for support.
-- Send error log to administrator.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Open the chat window and paste the error into the input field for support.</li>
+    <li>Send error log to administrator.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Contact admin to solve this issue.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Contact admin to solve this issue.</li>
+  </ul>
 </div>
 </div>
 
 Avoid overpromising solutions to errors unless the team is working on the problem.
 
-<div className="dos-and-donts" markdown="true">
- <div className="donts" markdown="true">
-   - Our team is working overtime to fix this for you and it will be fixed by morning.
+<div className="dos-and-donts">
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Our team is working overtime to fix this for you and it will be fixed by morning.</li>
+   </ul>
  </div>
 </div>
 

--- a/docs/guidelines/language/messaging/error-messages.mdx
+++ b/docs/guidelines/language/messaging/error-messages.mdx
@@ -233,11 +233,21 @@ Avoid overpromising solutions to errors unless the team is working on the proble
 
 ## Dos and Don’ts
 
-- Do make all messages consistent in terms of grammar and punctuation
-- Do take the blame when the error originates from your app or product
-- Do give users a reversible solution whenever possible
-- Don’t panic your users with dramatic or urgent language
-- Don’t use all upper case characters
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do make all messages consistent in terms of grammar and punctuation</li>
+      <li>Do take the blame when the error originates from your app or product</li>
+      <li>Do give users a reversible solution whenever possible</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t panic your users with dramatic or urgent language</li>
+      <li>Don’t use all upper case characters</li>
+    </ul>
+  </div>
+</div>
 
 
 ## Related

--- a/docs/guidelines/language/messaging/error-pages.md
+++ b/docs/guidelines/language/messaging/error-pages.md
@@ -27,45 +27,61 @@ We follow these templates when creating our main error pages. Although some of t
 
 Use the official code and definition so users can search for code terms and information themselves.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- 401 Unauthorized
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>401 Unauthorized</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- 401 Unlawful
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>401 Unlawful</li>
+  </ul>
 </div>
 </div>
 
 Use language suitable for all target users, including non-native English speakers.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- This page is not available right now. Try again later.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>This page is not available right now. Try again later.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- An unforeseen server-side condition prevented the fruitful processing of your request. This indicates an issue within our infrastructure, not a client-side input error.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>An unforeseen server-side condition prevented the fruitful processing of your request. This indicates an issue within our infrastructure, not a client-side input error.</li>
+  </ul>
 </div>
 </div>
 
 Avoid jokes, memes, emojis or casual wording in error pages for industrial applications.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- 401 Unauthorized
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>401 Unauthorized</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- Hold on! VIP access only! 🎩✨
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Hold on! VIP access only! 🎩✨</li>
+  </ul>
 </div>
 </div>
 
 Use sentence casing within the description with minimal punctuation and formatting.
 
-<div className="dos-and-donts" markdown>
-<div className="dos" markdown>
-- There is an error on this page. Try again later.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>There is an error on this page. Try again later.</li>
+  </ul>
 </div>
-<div className="donts" markdown>
-- There <ins>is</ins> an ERROR on this **page**! Try again later.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>There <ins>is</ins> an ERROR on this **page**! Try again later.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/messaging/infotips.mdx
+++ b/docs/guidelines/language/messaging/infotips.mdx
@@ -113,9 +113,19 @@ Avoid personal pronouns (you, we, our, etc.).
 
 ## Dos and Don’ts
 
-- Do keep infotips short and instructional
-- Don’t include critical or legal information
-- Don’t copy your user manual into your infotips
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do keep infotips short and instructional</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t include critical or legal information</li>
+      <li>Don’t copy your user manual into your infotips</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/infotips.mdx
+++ b/docs/guidelines/language/messaging/infotips.mdx
@@ -113,9 +113,9 @@ Avoid personal pronouns (you, we, our, etc.).
 
 ## Dos and Don’ts
 
-* Do keep infotips short and instructional
-* Don’t include critical or legal information
-* Don’t copy your user manual into your infotips
+- Do keep infotips short and instructional
+- Don’t include critical or legal information
+- Don’t copy your user manual into your infotips
 
 ## Related
 

--- a/docs/guidelines/language/messaging/infotips.mdx
+++ b/docs/guidelines/language/messaging/infotips.mdx
@@ -15,80 +15,98 @@ description: 'Infotips are short, context-sensitive messages that appear near us
 
 Use sentence case and end with a period (similar to tooltips).
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- View the current status of the production line.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>View the current status of the production line.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-- VIEW CURRENT STATUS OF PRODUCTION LINE
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>VIEW CURRENT STATUS OF PRODUCTION LINE</li>
+   </ul>
  </div>
 </div>
 
 Use infotips to support users with guidance and contextual information.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Maximum allowable hydraulic pressure (bar).
-- Current motor load in percentage.
-- Enables automatic system recalibration.
-- Unique identifier for the production batch.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Maximum allowable hydraulic pressure (bar).</li>
+    <li>Current motor load in percentage.</li>
+    <li>Enables automatic system recalibration.</li>
+    <li>Unique identifier for the production batch.</li>
+  </ul>
 </div>
 </div>
 
 Use infotips to help users understand complex terminology.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- SCADA System<br/>
-Supervisory Control and Data Acquisition: A system that monitors and controls industrial processes locally or at remote locations. <br/>
-- PLC cycle time<br/>
-This indicates the time (in milliseconds) it takes for the Programmable Logic Controller to execute one full scan of its program logic.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>SCADA System<br/>
+    Supervisory Control and Data Acquisition: A system that monitors and controls industrial processes locally or at remote locations. <br/></li>
+    <li>PLC cycle time<br/>
+    This indicates the time (in milliseconds) it takes for the Programmable Logic Controller to execute one full scan of its program logic.</li>
+  </ul>
 </div>
 </div>
 Use infotips to help users understand complex features and workflows.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Set thresholds<br/>
-Set project thresholds here. Adjust the value to trigger alerts when the temperature exceeds a specified limit (e.g. 80°C).<br/>
-- PID controller tuning<br/>
-Adjust these parameters (Proportional, Integral, Derivative) to optimize the system's response to errors and achieve stable control.
-- Schedule maintenance<br/>
-This workflow guides you through planning and assigning preventive maintenance tasks. First, select the asset, then define the task type, and finally set the recurrence schedule.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Set thresholds<br/>
+    Set project thresholds here. Adjust the value to trigger alerts when the temperature exceeds a specified limit (e.g. 80°C).<br/></li>
+    <li>PID controller tuning<br/>
+    Adjust these parameters (Proportional, Integral, Derivative) to optimize the system's response to errors and achieve stable control.</li>
+    <li>Schedule maintenance<br/>
+    This workflow guides you through planning and assigning preventive maintenance tasks. First, select the asset, then define the task type, and finally set the recurrence schedule.</li>
+  </ul>
 </div>
 </div>
 <br/>
 
 Use paragraphs to split complex information and use bullet points or lists for clarity.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Power meter monitoring<br/>
-Area: Production floor<br/>
-Present consumption: 120 kW<br/>
-Peak: 150 kW<br/>
-Button: Open meter list
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Power meter monitoring<br/>
+     Area: Production floor<br/>
+     Present consumption: 120 kW<br/>
+     Peak: 150 kW<br/>
+     Button: Open meter list</li>
+   </ul>
  </div>
 </div>
 
 Use imperative verbs (commands) for instructions and guidance.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Assign a unique identifier to each physical asset for tracking, maintenance scheduling, and inventory management.<br/>
-- Define and manage sequences of operations and ingredient quantities for automated production processes.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Assign a unique identifier to each physical asset for tracking, maintenance scheduling, and inventory management.<br/></li>
+    <li>Define and manage sequences of operations and ingredient quantities for automated production processes.</li>
+  </ul>
 </div>
 </div>
 
 Avoid personal pronouns (you, we, our, etc.).
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-- Select a device from the network to begin configuration.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Select a device from the network to begin configuration.</li>
+   </ul>
  </div>
 
- <div className="donts" markdown="true">
-- Select one of your devices to begin configuring your factory assets.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Select one of your devices to begin configuring your factory assets.</li>
+   </ul>
  </div>
 </div>
 

--- a/docs/guidelines/language/messaging/messages-overview.md
+++ b/docs/guidelines/language/messaging/messages-overview.md
@@ -29,114 +29,148 @@ First define your use case and message type from the list below, then use this o
 
 Use sentence casing for all message descriptions (except toast messages) and add full stops.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - Create zones from your dashboard.
-  - You have no new notifications.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Create zones from your dashboard.</li>
+     <li>You have no new notifications.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - Add regions from your dashboard
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Add regions from your dashboard</li>
+   </ul>
  </div>
 </div>
 
 Avoid overcommunicating by only adding relevant, beneficial information to your messages.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - We received your error report and will process it within 24 to 48 hours.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>We received your error report and will process it within 24 to 48 hours.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - The support team has received your bug report but they only work from 9–5 CEST time at the moment and there is a skeleton crew working over the summer.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>The support team has received your bug report but they only work from 9–5 CEST time at the moment and there is a skeleton crew working over the summer.</li>
+   </ul>
  </div>
 </div>
 
 Provide specifics, e.g. objects, values, reasons and solutions, instead of generic messaging.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - Failed to upload file due to connection error.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Failed to upload file due to connection error.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - Something happened.
-  - An error occurred.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Something happened.</li>
+     <li>An error occurred.</li>
+   </ul>
  </div>
 </div>
 
 Use urgent wording to signal serious and irreversible consequences from ignoring messages.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - Immediate software update required to save data securely.
-  - Update software now to save data.
-  - Contact support by 14:00 CET to avoid shutdown.
-  - Urgent: Order spare part replacement by August 31st for valve 532/a.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Immediate software update required to save data securely.</li>
+     <li>Update software now to save data.</li>
+     <li>Contact support by 14:00 CET to avoid shutdown.</li>
+     <li>Urgent: Order spare part replacement by August 31st for valve 532/a.</li>
+   </ul>
  </div>
 </div>
 
 Use the same key words in your messaging, but do not repeat headings and descriptions.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - **Heading:** Bad request<br />
-  **Description:** We could not process your request. Check and try again.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>**Heading:** Bad request<br />
+     **Description:** We could not process your request. Check and try again.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - **Heading:** Bad request<br/>
-  **Description:** Bad request.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>**Heading:** Bad request<br/>
+     **Description:** Bad request.</li>
+   </ul>
  </div>
 </div>
 
 Use the same grammar patterns across all your messaging within your product.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - No assets added. / No dashboards created. / No data downloaded.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>No assets added. / No dashboards created. / No data downloaded.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - No assets added. / You haven’t added any assets. / You have no assets yet.
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>No assets added. / You haven’t added any assets. / You have no assets yet.</li>
+   </ul>
  </div>
 </div>
 
 Avoid asking patronizing “Are you sure…?” questions to your expert users.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - Deleting this file removes all dependencies.
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Deleting this file removes all dependencies.</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - Are you sure you want to delete this file?
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Are you sure you want to delete this file?</li>
+   </ul>
  </div>
 </div>
 
 Use action labels that match the action of the message without mixing verbs or using synonyms.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - Close
-  - Save
-  - Continue
-  - Delete
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Close</li>
+     <li>Save</li>
+     <li>Continue</li>
+     <li>Delete</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - OK
-  - Confirm
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>OK</li>
+     <li>Confirm</li>
+   </ul>
  </div>
 </div>
 
 Allow users to go back to change actions and avoid “OK” which is often understood as “Yes”.
 
-<div className="dos-and-donts" markdown="true">
- <div className="dos" markdown="true">
-  - Heading: Unsaved changes <br />
-  Description: You are about to leave the page. Unsaved changes will be lost.<br />
-  Button: Exit without saving <br />
-  Button: Go back
+<div className="dos-and-donts">
+ <div className="dos">
+   <ul aria-label="Recommended practices">
+     <li>Heading: Unsaved changes <br />
+     Description: You are about to leave the page. Unsaved changes will be lost.<br />
+     Button: Exit without saving <br />
+     Button: Go back</li>
+   </ul>
  </div>
- <div className="donts" markdown="true">
-  - Description: Are you sure you want to cancel? <br />
-  Button: OK <br />
-  Button: Cancel <br />
-  Button: Yes 
+ <div className="donts">
+   <ul aria-label="Practices to avoid">
+     <li>Description: Are you sure you want to cancel? <br />
+     Button: OK <br />
+     Button: Cancel <br />
+     Button: Yes</li>
+   </ul>
  </div>
 </div>
 

--- a/docs/guidelines/language/messaging/messages-overview.md
+++ b/docs/guidelines/language/messaging/messages-overview.md
@@ -176,10 +176,20 @@ Allow users to go back to change actions and avoid “OK” which is often under
 
 ## Dos and Don’ts
 
-- Do first classify what kind of message is required
-- Do make a record or changelog of your messages for consistency and changes
-- Don’t over communicate with irrelevant or unrelated information
-- Don’t repeat the exact same wording in both the heading and description
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do first classify what kind of message is required</li>
+      <li>Do make a record or changelog of your messages for consistency and changes</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t over communicate with irrelevant or unrelated information</li>
+      <li>Don’t repeat the exact same wording in both the heading and description</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/non-critical-information-messages.mdx
+++ b/docs/guidelines/language/messaging/non-critical-information-messages.mdx
@@ -138,10 +138,20 @@ Use industrial icons only when absolutely necessary and avoid emojis.
 
 ## Dos and Don’ts
 
-- Do use an alternative modal if your notifications are too long and cover multiple points
-- Do make sure users understand the notification is not critical
-- Don’t add multiple pieces of information into one notification
-- Don’t insert multiple user actions into short notifications
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use an alternative modal if your notifications are too long and cover multiple points</li>
+      <li>Do make sure users understand the notification is not critical</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t add multiple pieces of information into one notification</li>
+      <li>Don’t insert multiple user actions into short notifications</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/non-critical-information-messages.mdx
+++ b/docs/guidelines/language/messaging/non-critical-information-messages.mdx
@@ -136,12 +136,12 @@ Use industrial icons only when absolutely necessary and avoid emojis.
 </div>
 </div>
 
-## Dos and Don'ts
+## Dos and Don’ts
 
-* Do use an alternative modal if your notifications are too long and cover multiple points
-* Do make sure users understand the notification is not critical
-* Don’t add multiple pieces of information into one notification
-* Don’t insert multiple user actions into short notifications
+- Do use an alternative modal if your notifications are too long and cover multiple points
+- Do make sure users understand the notification is not critical
+- Don’t add multiple pieces of information into one notification
+- Don’t insert multiple user actions into short notifications
 
 ## Related
 

--- a/docs/guidelines/language/messaging/non-critical-information-messages.mdx
+++ b/docs/guidelines/language/messaging/non-critical-information-messages.mdx
@@ -15,94 +15,124 @@ description: Non-critical information messages come from the system and keep use
 
 Keep messages short and concise.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Pump 3 cycle complete 14:32.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Pump 3 cycle complete 14:32.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- The operational sequence of Pump 3, located within Zone 2B, activated at 07:34 by admin 049 has completed its cycle (timestamp 14:32).
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>The operational sequence of Pump 3, located within Zone 2B, activated at 07:34 by admin 049 has completed its cycle (timestamp 14:32).</li>
+  </ul>
 </div>
 </div>
 
 Use a professional, informative tone for routine updates and only include relevant information.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- System backup completed at 21:00.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>System backup completed at 21:00.</li>
+  </ul>
 </div>
 
-<div className="donts" markdown="true">
-- Don’t worry! We’ll make sure your backup is complete before your morning coffee on Friday!
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Don’t worry! We’ll make sure your backup is complete before your morning coffee on Friday!</li>
+  </ul>
 </div>
 </div>
 
 Use clear timestamps for context, clarity, prioritization and record keeping.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Motor overload detected at 14:01:15
-- Emergency stop activated at 21:03:27
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Motor overload detected at 14:01:15</li>
+    <li>Emergency stop activated at 21:03:27</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Notification list: <br/>
-Motor 3 overheating <br/>
-Valve 7 malfunction
-- System shutdown initiated 10 minutes ago.
-- Lubrication check due for press machine 2 in 3 days.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Notification list: <br/>
+    Motor 3 overheating <br/>
+    Valve 7 malfunction</li>
+    <li>System shutdown initiated 10 minutes ago.</li>
+    <li>Lubrication check due for press machine 2 in 3 days.</li>
+  </ul>
 </div>
 </div>
 
 Avoid urgency wording as these types of notifications are typically not as critical as warnings.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- System backup complete.
-- System backup completed at 15:00.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>System backup complete.</li>
+    <li>System backup completed at 15:00.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- System backup done! Open and check now!
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>System backup done! Open and check now!</li>
+  </ul>
 </div>
 </div>
 
 Avoid adding user actions when possible as these notifications should not impact the user workflow.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Sensors calibrated. No further action required.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Sensors calibrated. No further action required.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Sensors calibrated. Click to check sensors (live link), calibration settings (live link) or manage your sensors (live link).
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Sensors calibrated. Click to check sensors (live link), calibration settings (live link) or manage your sensors (live link).</li>
+  </ul>
 </div>
 </div>
 
 Use sentence casing to align with our UX writing guidelines.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- System will be updated within three hours.
-- Scheduled maintenance for Line 4 starts at 14:00.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>System will be updated within three hours.</li>
+    <li>Scheduled maintenance for Line 4 starts at 14:00.</li>
+  </ul>
 </div>
 </div>
 
 Use minimal punctuation to keep notifications easy to read and without clutter or cognitive overload.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- System update on line 4 starts at 14:00.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>System update on line 4 starts at 14:00.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Notification: System update! Line: 4 / Starts: 14:00.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Notification: System update! Line: 4 / Starts: 14:00.</li>
+  </ul>
 </div>
 </div>
 
 Use industrial icons only when absolutely necessary and avoid emojis.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Line 3 shift schedule changed. See what's new.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Line 3 shift schedule changed. See what's new.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- 🔄 Line 3 shift schedule updated. 👉 See what’s new.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>🔄 Line 3 shift schedule updated. 👉 See what’s new.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/messaging/progress-updates.mdx
+++ b/docs/guidelines/language/messaging/progress-updates.mdx
@@ -191,10 +191,10 @@ Use transitional text to manage user expectations and reduce frustration for len
 </div>
 
 ## Dos and Don’ts
-* Do use the present simple progressive (continuous, -ing) verb form
-* Do use verbs before nouns to focus on the action
-* Don’t apologize for how long the progress takes
-* Don’t use vague phrases like: "Please wait."
+- Do use the present simple progressive (continuous, -ing) verb form
+- Do use verbs before nouns to focus on the action
+- Don’t apologize for how long the progress takes
+- Don’t use vague phrases like: "Please wait"
 
 ## Related
 

--- a/docs/guidelines/language/messaging/progress-updates.mdx
+++ b/docs/guidelines/language/messaging/progress-updates.mdx
@@ -191,10 +191,21 @@ Use transitional text to manage user expectations and reduce frustration for len
 </div>
 
 ## Dos and Don’ts
-- Do use the present simple progressive (continuous, -ing) verb form
-- Do use verbs before nouns to focus on the action
-- Don’t apologize for how long the progress takes
-- Don’t use vague phrases like: "Please wait"
+
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do use the present simple progressive (continuous, -ing) verb form</li>
+      <li>Do use verbs before nouns to focus on the action</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don't apologize for how long the progress takes</li>
+      <li>Don't use vague phrases like: "Please wait"</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/progress-updates.mdx
+++ b/docs/guidelines/language/messaging/progress-updates.mdx
@@ -14,137 +14,179 @@ description: While some companies use humorous text like "Chopping the onions…
 
 Use sentence case to align with our UX writing guidelines.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Downloading assets…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Downloading assets…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Downloading Assets…
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Downloading Assets…</li>
+  </ul>
 </div>
 </div>
 
 Use the present simple progressive (continuous, -ing) verb form to indicate ongoing actions.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Loading…
-- Downloading…
-- Charging…
-- Saving…
-- Searching…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Loading…</li>
+    <li>Downloading…</li>
+    <li>Charging…</li>
+    <li>Saving…</li>
+    <li>Searching…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Been loading…
-- To be loading…
-- Will be loading…
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Been loading…</li>
+    <li>To be loading…</li>
+    <li>Will be loading…</li>
+  </ul>
 </div>
 </div>
 
 Use verbs before nouns to focus on the action and make messages easier to scan.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Loading file…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Loading file…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- File loading…
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>File loading…</li>
+  </ul>
 </div>
 </div>
 
 Use horizontal ellipses (…) after the verb without a space instead of adding three full stops (unicode U+2026, Mac Option+/Windows ALT+0133).
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Loading…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Loading…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Loading …
-- Processing⋰
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Loading …</li>
+    <li>Processing⋰</li>
+  </ul>
 </div>
 </div>
 
 Use ellipses for text with numbers or the object to show a running process.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Uploading 5 items…
-- Uploading items…
-- Processing request…
-- Saving settings…
-- Saving changes…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Uploading 5 items…</li>
+    <li>Uploading items…</li>
+    <li>Processing request…</li>
+    <li>Saving settings…</li>
+    <li>Saving changes…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Uploading 1 file
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Uploading 1 file</li>
+  </ul>
 </div>
 </div>
 
 Avoid ellipses to show time remaining and approximate or unknown times as they're status indicators, not actions.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- 5 minutes remaining
-- About 33 minutes remaining
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>5 minutes remaining</li>
+    <li>About 33 minutes remaining</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- 5 minutes remaining…
-- About 33 minutes remaining…
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>5 minutes remaining…</li>
+    <li>About 33 minutes remaining…</li>
+  </ul>
 </div>
 </div>
 
 Change verb form without ellipses when possible in buttons with loading spinners to avoid visual clutter.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Download → Downloading → Downloaded
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Download → Downloading → Downloaded</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Download → Downloading… → Downloaded
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Download → Downloading… → Downloaded</li>
+  </ul>
 </div>
 </div>
 
 Use the correct verb form without using ellipses to show background processes. 
  
- <div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Download → Downloading → Downloaded
+ <div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Download → Downloading → Downloaded</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Download → Downloading… → Downloaded
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Download → Downloading… → Downloaded</li>
+  </ul>
 </div>
 </div>
 
 Use specific and definitive text to make users aware of what is happening and how long the process takes.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Downloading…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Downloading…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Please wait.
-- Thank you for waiting.
-- Just a moment.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Please wait.</li>
+    <li>Thank you for waiting.</li>
+    <li>Just a moment.</li>
+  </ul>
 </div>
 </div>
 
 Use informative text and actions when multiple processes are happening at the same time.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Carrying out tasks…
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Carrying out tasks…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Thank you for waiting.
-- Just a moment.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Thank you for waiting.</li>
+    <li>Just a moment.</li>
+  </ul>
 </div>
 </div>
 
 Use transitional text to manage user expectations and reduce frustration for lengthy processes.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Processing your request. This usually takes about 1–2 minutes.
-- This step takes a bit longer than usual.
-- We’re preparing your dashboard. Once it’s ready, you’ll be able to customize your view.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Processing your request. This usually takes about 1–2 minutes.</li>
+    <li>This step takes a bit longer than usual.</li>
+    <li>We’re preparing your dashboard. Once it’s ready, you’ll be able to customize your view.</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/messaging/time-related-messages.mdx
+++ b/docs/guidelines/language/messaging/time-related-messages.mdx
@@ -198,9 +198,19 @@ Provide clear, actionable choices for next steps and user autonomy.
 
 ## Dos and Don’ts
 
-- Do add user actions when possible, e.g. buttons or links
-- Don’t leave users wondering if the app is stuck or broken
-- Don’t guess unknown time frames
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do add user actions when possible, e.g. buttons or links</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t leave users wondering if the app is stuck or broken</li>
+      <li>Don’t guess unknown time frames</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/time-related-messages.mdx
+++ b/docs/guidelines/language/messaging/time-related-messages.mdx
@@ -14,98 +14,112 @@ description: Time-related messages help users understand how long processes take
 
 Use a specific time or time frame whenever possible.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - System update on Monday, August 22, 2025: 06:00–08:00
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>System update on Monday, August 22, 2025: 06:00–08:00</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-    - Upcoming system update: 22 August
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Upcoming system update: 22 August</li>
+    </ul>
   </div>
 </div>
 
 Use the user’s time zone when providing any kind of time indication.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - Failed to synchronize data. Synchronized at 12:45 BST.
-    - System maintenance scheduled for Wednesday, August 22: 02:00–04:00 BST
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Failed to synchronize data. Synchronized at 12:45 BST.</li>
+      <li>System maintenance scheduled for Wednesday, August 22: 02:00–04:00 BST</li>
+    </ul>
   </div>
 </div>
 
 When necessary, add time zones with the UTC in brackets.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Failed to synchronize data. Last successful sync: 12:45 BST (UTC+1) -
-    System maintenance scheduled for Wednesday, August 22, 02:00–04:00 BST
-    (UTC+1).
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Failed to synchronize data. Last successful sync: 12:45 BST (UTC+1) -
+      System maintenance scheduled for Wednesday, August 22, 02:00–04:00 BST
+      (UTC+1).</li>
+    </ul>
   </div>
 </div>
 
 Avoid generic time-related terms like later, soon, sometime, etc.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Update starts Tuesday, October 1, 2026: 02:00–04:00
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Update starts Tuesday, October 1, 2026: 02:00–04:00</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-
-    - Update starts soon.
-    - Update starts later today.
-    - Update takes a few moments.
-    - Update takes a while.
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Update starts soon.</li>
+      <li>Update starts later today.</li>
+      <li>Update takes a few moments.</li>
+      <li>Update takes a while.</li>
+    </ul>
   </div>
 </div>
 
 Use "will" to indicate certainty and avoid "may" or "might" which sound uncertain.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Update will take a few minutes.
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Update will take a few minutes.</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-
-    - Update may take a few minutes.
-    - Update might take a few minutes.
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Update may take a few minutes.</li>
+      <li>Update might take a few minutes.</li>
+    </ul>
   </div>
 </div>
 
 Avoid adding messages when the process takes less than ten seconds.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="donts" markdown="true">
-    - This process takes a few seconds.
+<div className="dos-and-donts">
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>This process takes a few seconds.</li>
+    </ul>
   </div>
 </div>
 
 Use countdowns to alert users to time-sensitive information.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - Session expiring in 04:25 minutes.
-    - Automatic logout in 03:45 minutes.
-    - Meeting starts in 5 minutes.
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Session expiring in 04:25 minutes.</li>
+      <li>Automatic logout in 03:45 minutes.</li>
+      <li>Meeting starts in 5 minutes.</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-    - Migration starts in 1 hour.
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Migration starts in 1 hour.</li>
+    </ul>
   </div>
 </div>
 
 Use consistent wording in the UI and add specific volumes with progress indicators.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - Data volume: 45/300 MB
-    - Saving data… 50 of 300 MB saved
-    - System update: 45% complete
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Data volume: 45/300 MB</li>
+      <li>Saving data… 50 of 300 MB saved</li>
+      <li>System update: 45% complete</li>
+    </ul>
   </div>
 </div>
 
@@ -113,26 +127,28 @@ Use consistent wording in the UI and add specific volumes with progress indicato
 
 Use a realistic time range or an estimated time window if possible.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - The system update can take a few hours.
-    - The update will finish within the next 60 minutes.
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>The system update can take a few hours.</li>
+      <li>The update will finish within the next 60 minutes.</li>
+    </ul>
   </div>
 </div>
 
 Be transparent and use passive voice when you need to be unspecific.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - Due to the size of the data migration, it is estimated to take between 4-6 hours.
-    - Data is being fetched from multiple sources, and the completion time varies depending on system conditions.
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Due to the size of the data migration, it is estimated to take between 4-6 hours.</li>
+      <li>Data is being fetched from multiple sources, and the completion time varies depending on system conditions.</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-    - Due to the size of the migration, we have no idea when it will finish.
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Due to the size of the migration, we have no idea when it will finish.</li>
+    </ul>
   </div>
 </div>
 
@@ -140,43 +156,43 @@ Be transparent and use passive voice when you need to be unspecific.
 
 Inform users whether or not they can continue working during a process.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - The application will not be available during the update. We’ll notify you when it’s ready.
-    - The application is not available during the update.
-    - You can continue working until the update begins.
-    - Installation files are downloaded in the background.
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>The application will not be available during the update. We’ll notify you when it’s ready.</li>
+      <li>The application is not available during the update.</li>
+      <li>You can continue working until the update begins.</li>
+      <li>Installation files are downloaded in the background.</li>
+    </ul>
   </div>
 </div>
 
 Clearly communicate any consequences related to user actions (or inaction).
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - You can only postpone this update once.
-    - An update is scheduled to automatically install tonight.
-    - The installation will be updated tonight.
-    - Update must be installed before Friday, September 12, 2026.
-    - The device will restart during the update.
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>You can only postpone this update once.</li>
+      <li>An update is scheduled to automatically install tonight.</li>
+      <li>The installation will be updated tonight.</li>
+      <li>Update must be installed before Friday, September 12, 2026.</li>
+      <li>The device will restart during the update.</li>
+    </ul>
   </div>
 </div>
 
 Provide clear, actionable choices for next steps and user autonomy.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - Postpone
-    - Remind me tomorrow
-    - Update now
-    - More information
-    - Stop
-    - Pause
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Postpone</li>
+      <li>Remind me tomorrow</li>
+      <li>Update now</li>
+      <li>More information</li>
+      <li>Stop</li>
+      <li>Pause</li>
+    </ul>
   </div>
 </div>
 

--- a/docs/guidelines/language/messaging/time-related-messages.mdx
+++ b/docs/guidelines/language/messaging/time-related-messages.mdx
@@ -17,7 +17,7 @@ Use a specific time or time frame whenever possible.
 <div className="dos-and-donts">
   <div className="dos">
     <ul aria-label="Recommended practices">
-      <li>System update on Monday, August 22, 2025: 06:00–08:00</li>
+      <li>System update on Friday, August 22, 2025: 06:00–08:00</li>
     </ul>
   </div>
   <div className="donts">
@@ -55,7 +55,7 @@ Avoid generic time-related terms like later, soon, sometime, etc.
 <div className="dos-and-donts">
   <div className="dos">
     <ul aria-label="Recommended practices">
-      <li>Update starts Tuesday, October 1, 2026: 02:00–04:00</li>
+      <li>Update starts Thursday, October 1, 2026: 02:00–04:00</li>
     </ul>
   </div>
   <div className="donts">

--- a/docs/guidelines/language/messaging/toast-messages.mdx
+++ b/docs/guidelines/language/messaging/toast-messages.mdx
@@ -150,10 +150,20 @@ Avoid using "successful" and "successfully" as this adds to the reading load and
 
 ## Dos and Don’ts
 
-- Do add extra time when there is an action option
-- Do use consistent wording to help users scan toast messages easier
-- Don’t use full sentences or complex verb forms
-- Don’t add an action unless absolutely necessary
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do add extra time when there is an action option</li>
+      <li>Do use consistent wording to help users scan toast messages easier</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use full sentences or complex verb forms</li>
+      <li>Don’t add an action unless absolutely necessary</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/toast-messages.mdx
+++ b/docs/guidelines/language/messaging/toast-messages.mdx
@@ -148,7 +148,7 @@ Avoid using "successful" and "successfully" as this adds to the reading load and
   </div>
 </div>
 
-## Dos and Don'ts
+## Dos and Don’ts
 
 - Do add extra time when there is an action option
 - Do use consistent wording to help users scan toast messages easier

--- a/docs/guidelines/language/messaging/toast-messages.mdx
+++ b/docs/guidelines/language/messaging/toast-messages.mdx
@@ -26,113 +26,125 @@ Although always short, toast messages vary in length and complexity:
 
 Use simple past tense verbs to state what happened.
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-    - Assets uploaded
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Assets uploaded</li>
+    </ul>
   </div>
-  <div className="donts" markdown>
-    - Assets have been uploaded
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Assets have been uploaded</li>
+    </ul>
   </div>
 </div>
 
 Use "not" or "failed to" with the verb to signal failure.
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-
-    - File not imported
-    - Failed to import file
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>File not imported</li>
+      <li>Failed to import file</li>
+    </ul>
   </div>
-  <div className="donts" markdown>
-    - File type not recognized
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>File type not recognized</li>
+    </ul>
   </div>
 </div>
 
 Use present progressive verbs for background or ongoing actions.
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-    - Update application → Updating application… → Application updated
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Update application → Updating application… → Application updated</li>
+    </ul>
   </div>
 </div>
 
 Use the same verbs and nouns from the dialog and button that initiated the toast message.
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-
-    - Upload file → File uploaded
-    - Connect → Gateway connected
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Upload file → File uploaded</li>
+      <li>Connect → Gateway connected</li>
+    </ul>
   </div>
-  <div className="donts" markdown>
-
-    - Upload file → File added
-    - Connect → Gateway established
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Upload file → File added</li>
+      <li>Connect → Gateway established</li>
+    </ul>
   </div>
 </div>
 
 Avoid punctuation as this takes up extra space and adds to visual clutter.
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-    - Scan finished
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Scan finished</li>
+    </ul>
   </div>
-  <div className="donts" markdown>
-
-    - Scan finished.
-    - Scan not finished!
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Scan finished.</li>
+      <li>Scan not finished!</li>
+    </ul>
   </div>
 </div>
 
 Avoid adding additional words or verbs such as "you", "your", "is" or "was".
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-
-    - Maintenance scheduled
-    - Asset onboarded
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Maintenance scheduled</li>
+      <li>Asset onboarded</li>
+    </ul>
   </div>
-  <div className="donts" markdown>
-
-    - Your maintenance was scheduled
-    - Onboarding for asset was successfully completed
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Your maintenance was scheduled</li>
+      <li>Onboarding for asset was successfully completed</li>
+    </ul>
   </div>
 </div>
 
 Avoid generic toast messages, such as "successful", "unsuccessful", "error" and "failure".
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-
-    - Connected
-    - Failed to connect
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Connected</li>
+      <li>Failed to connect</li>
+    </ul>
   </div>
-  <div className="donts" markdown>
-
-    - Successful
-    - Failed
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Successful</li>
+      <li>Failed</li>
+    </ul>
   </div>
 </div>
 
 Avoid using "successful" and "successfully" as this adds to the reading load and effort.
 
-<div className="dos-and-donts" markdown>
-  <div className="dos" markdown>
-    - Connected
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Connected</li>
+    </ul>
   </div>
-  <div className="donts" markdown>
-
-    - Connection successfully established
-    - Connection established successfully
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Connection successfully established</li>
+      <li>Connection established successfully</li>
+    </ul>
   </div>
 </div>
 

--- a/docs/guidelines/language/messaging/tooltips.mdx
+++ b/docs/guidelines/language/messaging/tooltips.mdx
@@ -132,15 +132,16 @@ Avoid repeating text already visible and readable on the screen.
   </div>
 </div>
 
-## Dos and Don'ts
+## Dos and Don’ts
 
-- Do write tooltips to give more context about complex features
-- Do write tooltips to support beginners
-- Don’t use tooltips to convey lengthy or critical information
-- Don’t add irrelevant information, instead focus on context
+- Do write tooltips to give context for complex features
+- Do write tooltips to support new users
+- Don’t use tooltips for lengthy updates use [Toast messages](./toast-messages.mdx) instead
+- Don’t use tooltips for critical blocking feedback use [Message modal](../../../components/message-modal/index.mdx) instead
 
 ## Related
 
 - [Toast messages](./toast-messages.mdx)
+- [Message modal](../../../components/message-modal/index.mdx)
 - [Non-critical information messages](./non-critical-information-messages.mdx)
 - [Messages overview](./messages-overview.md)

--- a/docs/guidelines/language/messaging/tooltips.mdx
+++ b/docs/guidelines/language/messaging/tooltips.mdx
@@ -14,90 +14,108 @@ import { iconEditDocument } from '@siemens/ix-icons/icons';
 
 Use tooltips to define icons and show control names.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - Edit
-    - Delete
-    - Log out
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Edit</li>
+      <li>Delete</li>
+      <li>Log out</li>
+    </ul>
   </div>
 </div>
 
 Avoid punctuation or periods for tool names or icons.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-
-    - Edit
-    - Open file
-
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Edit</li>
+      <li>Open file</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-
-    - Edit.
-    - Open file.
-
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Edit.</li>
+      <li>Open file.</li>
+    </ul>
   </div>
 </div>
 
 Use sentence case and a period if the tooltip is a complete sentence or multiple sentences.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Add users to project.
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Add users to project.</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-    - Add new users to project
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Add new users to project</li>
+    </ul>
   </div>
 </div>
 
 Use verbs to start your tooltip and avoid passive voice.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Create KPI tables.
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Create KPI tables.</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-    - Tables are created.
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Tables are created.</li>
+    </ul>
   </div>
 </div>
 
 Avoid complicated sentence constructions, e.g. no relative clauses.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Share with team members.
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Share with team members.</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-    - Projects can be shared with team members who work with you.
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Projects can be shared with team members who work with you.</li>
+    </ul>
   </div>
 </div>
 
 Use a heading with a short description for longer tooltips.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Heading: Cycle time input
-    <br />
-    Description: Set the duration of each production cycle in seconds.
-    <br />
-    - Heading: Log history
-    <br />
-    Description: View historical logs of machine activity and operator actions.
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Heading: Cycle time input
+      <br />
+      Description: Set the duration of each production cycle in seconds.
+      <br /></li>
+      <li>Heading: Log history
+      <br />
+      Description: View historical logs of machine activity and operator actions.</li>
+    </ul>
   </div>
 </div>
 
 Avoid repeating text already visible and readable on the screen.
 
-<div className="dos-and-donts" markdown="true">
-  <div className="dos" markdown="true">
-    - Edit (as icon<IxIcon name={iconEditDocument} size="16"></IxIcon>) <br />
-    Tooltip: Edit
+<div className="dos-and-donts">
+  <div className="dos">
+    <ul aria-label="Recommended practices">
+      <li>Edit (as icon<IxIcon name={iconEditDocument} size="16"></IxIcon>) <br />
+      Tooltip: Edit</li>
+    </ul>
   </div>
-  <div className="donts" markdown="true">
-    - Edit (as text) <br />
-    Tooltip: Edit
+  <div className="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Edit (as text) <br />
+      Tooltip: Edit</li>
+    </ul>
   </div>
 </div>
 

--- a/docs/guidelines/language/messaging/tooltips.mdx
+++ b/docs/guidelines/language/messaging/tooltips.mdx
@@ -91,13 +91,21 @@ Use a heading with a short description for longer tooltips.
 <div className="dos-and-donts">
   <div className="dos">
     <ul aria-label="Recommended practices">
-      <li>Heading: Cycle time input
-      <br />
-      Description: Set the duration of each production cycle in seconds.
-      <br /></li>
-      <li>Heading: Log history
-      <br />
-      Description: View historical logs of machine activity and operator actions.</li>
+      <li>
+        <div>
+          Heading: Cycle time input
+          <br />
+          Description: Set the duration of each production cycle in seconds.
+          <br />
+        </div>
+      </li>
+      <li>
+        <div>
+          Heading: Log history
+          <br />
+          Description: View historical logs of machine activity and operator actions.
+        </div>
+      </li>
     </ul>
   </div>
 </div>
@@ -107,14 +115,19 @@ Avoid repeating text already visible and readable on the screen.
 <div className="dos-and-donts">
   <div className="dos">
     <ul aria-label="Recommended practices">
-      <li>Edit (as icon<IxIcon name={iconEditDocument} size="16"></IxIcon>) <br />
-      Tooltip: Edit</li>
+      <li>
+        <span>Edit (as icon <IxIcon name={iconEditDocument} size="16"></IxIcon>)</span>
+        <br />
+        Tooltip: Edit
+      </li>
     </ul>
   </div>
   <div className="donts">
     <ul aria-label="Practices to avoid">
-      <li>Edit (as text) <br />
-      Tooltip: Edit</li>
+      <li>
+        Edit (as text) <br />
+        Tooltip: Edit
+      </li>
     </ul>
   </div>
 </div>

--- a/docs/guidelines/language/messaging/tooltips.mdx
+++ b/docs/guidelines/language/messaging/tooltips.mdx
@@ -134,10 +134,20 @@ Avoid repeating text already visible and readable on the screen.
 
 ## Dos and Don’ts
 
-- Do write tooltips to give context for complex features
-- Do write tooltips to support new users
-- Don’t use tooltips for lengthy updates use [Toast messages](./toast-messages.mdx) instead
-- Don’t use tooltips for critical blocking feedback use [Message modal](../../../components/message-modal/index.mdx) instead
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do write tooltips to give context for complex features</li>
+      <li>Do write tooltips to support new users</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use tooltips for lengthy updates use [Toast messages](./toast-messages.mdx) instead</li>
+      <li>Don’t use tooltips for critical blocking feedback use [Message modal](../../../components/message-modal/index.mdx) instead</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/messaging/warning-messages.mdx
+++ b/docs/guidelines/language/messaging/warning-messages.mdx
@@ -24,113 +24,145 @@ We follow this three-step approach when creating our warning messages. This ensu
 
 Use warning messages only when an action or awareness is genuinely needed.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Temperature readings from Zone 3 approaching 30°. Check cooling system and ensure all windows and doors are closed.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Temperature readings from Zone 3 approaching 30°. Check cooling system and ensure all windows and doors are closed.</li>
+  </ul>
 </div>
 </div>
 
 Use clear, understandable titles and avoid generic warning messages.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Temperature approaching 30°
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Temperature approaching 30°</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Temperature warning
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Temperature warning</li>
+  </ul>
 </div>
 </div>
 
 Provide specific and clear consequences and solutions.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Heading: Leave without saving<br/>
-Description: You’re about to leave this page. Unsaved changes will be lost. Go back to save changes or exit without saving.<br/>
-Button: Leave without saving<br/>
-Button: Go back
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: Leave without saving<br/>
+    Description: You’re about to leave this page. Unsaved changes will be lost. Go back to save changes or exit without saving.<br/>
+    Button: Leave without saving<br/>
+    Button: Go back</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Do you want to leave the page?<br/>
-Button: Continue<br/>
-Button: OK<br/>
-Button: Cancel
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Do you want to leave the page?<br/>
+    Button: Continue<br/>
+    Button: OK<br/>
+    Button: Cancel</li>
+  </ul>
 </div>
 </div>
 
 Avoid using words like "may", "might" or "possibly will" when explaining problems.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Your changes will be lost if not saved.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Your changes will be lost if not saved.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Your changes might be lost if not saved.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Your changes might be lost if not saved.</li>
+  </ul>
 </div>
 </div>
 
 Include links to help pages or troubleshooting steps to avoid the consequences when possible.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Heading: Login attempt from unknown device<br/>
-Description: Review access settings or security guidelines to prevent unauthorized access.<br/>
-Button: Open guidelines<br/>
-Button: Open access settings
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: Login attempt from unknown device<br/>
+    Description: Review access settings or security guidelines to prevent unauthorized access.<br/>
+    Button: Open guidelines<br/>
+    Button: Open access settings</li>
+  </ul>
 </div>
 </div>
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Heading: Unauthorized access attempt on Control Panel A<br/>
-Description: Review access logs and verify user credentials.<br/>
-Button: Open access logs
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: Unauthorized access attempt on Control Panel A<br/>
+    Description: Review access logs and verify user credentials.<br/>
+    Button: Open access logs</li>
+  </ul>
 </div>
 </div>
 
 Avoid repeating your message in both the heading and description.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Heading: Pressure in Tank B approaching limit<br/>
-Description: Initiate release protocol to avoid exceeding threshold.
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: Pressure in Tank B approaching limit<br/>
+    Description: Initiate release protocol to avoid exceeding threshold.</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Heading: Pressure in Tank B approaching limit<br/>
-Description: Pressure in Tank B approaching limit so initiate release protocol.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Heading: Pressure in Tank B approaching limit<br/>
+    Description: Pressure in Tank B approaching limit so initiate release protocol.</li>
+  </ul>
 </div>
 </div>
 
 Avoid asking "Are you sure?" as this is vague, has no context, consequences and causes hesitation.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- This action will delete all sensor data from the last 24 hours. Do you want to proceed and delete?
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>This action will delete all sensor data from the last 24 hours. Do you want to proceed and delete?</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Are you sure you want to delete?
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Are you sure you want to delete?</li>
+  </ul>
 </div>
 </div>
 
 Use clear, urgent wording for irreversible actions.
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-- Heading: Reset device<br/>
-Description: A reset restores the device to its factory settings, deleting all applications and user data. This action cannot be undone.<br/>
-Button: Reset<br/>
-Button: Cancel
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Heading: Reset device<br/>
+    Description: A reset restores the device to its factory settings, deleting all applications and user data. This action cannot be undone.<br/>
+    Button: Reset<br/>
+    Button: Cancel</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-- Press reset to proceed.
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Press reset to proceed.</li>
+  </ul>
 </div>
 </div>
 
 Avoid using all uppercase text as it can be difficult to read and may seem like we’re shouting.
 
-<div className="dos-and-donts" markdown="true">
-<div className="donts" markdown="true">
-- WARNING!! FAILURE! IMMEDIATE ACTION REQUIRED!!
+<div className="dos-and-donts">
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>WARNING!! FAILURE! IMMEDIATE ACTION REQUIRED!!</li>
+  </ul>
 </div>
 </div>
 

--- a/docs/guidelines/language/messaging/warning-messages.mdx
+++ b/docs/guidelines/language/messaging/warning-messages.mdx
@@ -168,11 +168,11 @@ Avoid using all uppercase text as it can be difficult to read and may seem like 
 
 ## Dos and Don’ts
 
-* Do be consistent by re-using the verbs of the message and buttons
-* Do make sure users understand the warning’s context
-* Do give users actions to avoid any negative consequences
-* Don’t use "please" with the call to action or options
-* Don’t use patronizing questions such as "Are you sure…?"
+- Do be consistent by re-using the verbs of the message and buttons
+- Do make sure users understand the warning’s context
+- Do give users actions to avoid any negative consequences
+- Don’t use "please" with the call to action or options
+- Don’t use patronizing questions such as "Are you sure…?"
 
 ## Related
 

--- a/docs/guidelines/language/messaging/warning-messages.mdx
+++ b/docs/guidelines/language/messaging/warning-messages.mdx
@@ -168,11 +168,21 @@ Avoid using all uppercase text as it can be difficult to read and may seem like 
 
 ## Dos and Don’ts
 
-- Do be consistent by re-using the verbs of the message and buttons
-- Do make sure users understand the warning’s context
-- Do give users actions to avoid any negative consequences
-- Don’t use "please" with the call to action or options
-- Don’t use patronizing questions such as "Are you sure…?"
+<div class="dos-and-donts">
+  <div class="dos">
+    <ul aria-label="Recommended practices">
+      <li>Do be consistent by re-using the verbs of the message and buttons</li>
+      <li>Do make sure users understand the warning’s context</li>
+      <li>Do give users actions to avoid any negative consequences</li>
+    </ul>
+  </div>
+  <div class="donts">
+    <ul aria-label="Practices to avoid">
+      <li>Don’t use "please" with the call to action or options</li>
+      <li>Don’t use patronizing questions such as "Are you sure…?"</li>
+    </ul>
+  </div>
+</div>
 
 ## Related
 

--- a/docs/guidelines/language/punctuation.md
+++ b/docs/guidelines/language/punctuation.md
@@ -85,36 +85,36 @@ Always consider whether necessary
 
 - Numbers: Use No. as an abbreviation for number, no spacing between abbreviated No. and number: No.8
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 11am
-- Monday, January 12, 2021
-- €999.50
-- €2.5 million
-- $400,456.50
-- £320
-- 30 mm
-- 10 oz
-- 10-40%
-- No.7
-- Number 7
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>11am</li>
+    <li>Monday, January 12, 2021</li>
+    <li>€999.50</li>
+    <li>€2.5 million</li>
+    <li>$400,456.50</li>
+    <li>£320</li>
+    <li>30 mm</li>
+    <li>10 oz</li>
+    <li>10-40%</li>
+    <li>No.7</li>
+    <li>Number 7</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 11 a.m.
-- Monday, 12 January 2021
-- €999,50
-- €2,5 million
-- $400.456,50
-- 320£
-- 30 mms
-- 10 oz.
-- 10–40%
-- #7
-- Num 7
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>11 a.m.</li>
+    <li>Monday, 12 January 2021</li>
+    <li>€999,50</li>
+    <li>€2,5 million</li>
+    <li>$400.456,50</li>
+    <li>320£</li>
+    <li>30 mms</li>
+    <li>10 oz.</li>
+    <li>10–40%</li>
+    <li>#7</li>
+    <li>Num 7</li>
+  </ul>
 </div>
 </div>
 
@@ -130,22 +130,22 @@ Always consider whether necessary
 
 - Add a space before unit of measurement
 
-<div className="dos-and-donts" markdown="true">
-<div className="dos" markdown="true">
-
-- 50%
-- 11am
-- Tuesday: no data
-- Browse…
-
+<div className="dos-and-donts">
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>50%</li>
+    <li>11am</li>
+    <li>Tuesday: no data</li>
+    <li>Browse…</li>
+  </ul>
 </div>
-<div className="donts" markdown="true">
-
-- 50 %
-- 11 am
-- Tuesday: no data
-- Browse …
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>50 %</li>
+    <li>11 am</li>
+    <li>Tuesday: no data</li>
+    <li>Browse …</li>
+  </ul>
 </div>
 </div>
 
@@ -161,25 +161,21 @@ Always consider whether necessary
 
 - Make lists parallel, i.e. all items / bullets have the same look, length, feel, punctuation, capitalization
 
-<div className="dos-and-donts" markdown="true">
+<div className="dos-and-donts">
 
-<div className="dos" markdown="true">
-
-  #### Activate comments within your smartphone to
-
-  - Write comments
-  - Respond to comments
-  - Approve work orders
-
+<div className="dos">
+  <ul aria-label="Recommended practices">
+    <li>Write comments</li>
+    <li>Respond to comments</li>
+    <li>Approve work orders</li>
+  </ul>
 </div>
 
-<div className="donts" markdown="true">
-
-  #### Activate comments within your smartphone to
-
-  - Write comments
-  - Respond to comments
-  - Approve work orders by adding your fingerprint to your user management section in your smartphone.
-
+<div className="donts">
+  <ul aria-label="Practices to avoid">
+    <li>Write comments</li>
+    <li>Respond to comments</li>
+    <li>Approve work orders by adding your fingerprint to your user management section in your smartphone.</li>
+  </ul>
 </div>
 </div>


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Dos and don'ts sections will not be distinguishable for screen readers

GitHub Issue Number: IX-4113

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Markdown lists converted to HTML ul
- ARIA-labels added
- UPDATE: Accepted by ACC (a11y competence center)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized “Dos and Don’ts” guidance across component and language/guideline pages into a consistent, accessible layout that clearly separates recommended practices from practices to avoid.
  * Updated examples and formatting to use structured lists with accessible labels, improving readability and navigation for assistive technologies.
  * Refreshed some “Related” links and tightened a few example items/wording where content needed alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->