### PR TITLE
fix(search): move focus ring to the search form container

### DIFF
--- a/src/scss/overwrite/_searchBar.scss
+++ b/src/scss/overwrite/_searchBar.scss
@@ -44,6 +44,16 @@
   --aa-primary-color-rgb: var(--theme-color-std-text);
   color: var(--theme-color-std-text);
 
+  // The search field is only one part of the form, so the focus ring belongs on
+  // the whole form. Otherwise it is drawn inside the form and overlaps its
+  // border, the submit icon and the clear button.
+  // `!important` is required because autocomplete.js resets the outline with an
+  // equally specific rule that is loaded later.
+  &:focus-within {
+    outline: 1px solid var(--theme-color-focus-bdr) !important;
+    outline-offset: var(--theme-focus-outline-offset);
+  }
+
   .aa-InputWrapperSuffix,
   .aa-InputWrapperPrefix {
     background-color: var(--theme-input--background);
@@ -53,6 +63,13 @@
   .aa-Input {
     background-color: var(--theme-input--background);
     box-shadow: none;
+  }
+
+  // Wins over the global `input:focus` rule from `@siemens/ix`.
+  .aa-Input:focus,
+  .aa-Input:focus-visible {
+    outline: none !important;
+    box-shadow: none !important;
   }
 
   .aa-Input::placeholder {


### PR DESCRIPTION
## What
Fixes the focus outline on the site search input so it no longer overlaps the search icon, text, and clear button in dark theme (and light theme too).

## Why
The global `input:focus` style from `@siemens/ix` draws an offset outline directly on the `<input>`. On the search field that ring sits inside the surrounding `.aa-Form` container, so it overlapped the form border and crowded the icons.

## Fix
- Suppress the outline on `.aa-Input` itself.
- Show the focus ring on the `.aa-Form` container instead (`:focus-within`), which already has room around it.

Verified locally in both themes by building and serving the site and focusing the search input.

Fixes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved search bar focus styling for clearer keyboard navigation.
  - Added a consistent focus ring around the complete search field.
  - Prevented overlapping or clipped focus effects on the input and clear button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->