### PR TITLE
docs: adapt community link and hide news pill

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -281,12 +281,14 @@ const config: Config = {
           position: 'left',
           label: 'Styles',
         },
+        /* Hide news pill until next major release
         {
           type: 'custom-news-pill',
           position: 'left',
           label: 'Release 5.0.0',
           value: '/blog/2026/05/21/release-5',
         },
+        */
         {
           type: 'custom-version-selection',
           position: 'right',
@@ -334,8 +336,8 @@ const config: Config = {
               href: 'https://github.com/siemens/ix',
             },
             {
-              label: 'iX Community',
-              href: 'https://community.siemens.com/c/ix',
+              label: 'Viva Engage Community',
+              href: 'https://engage.cloud.microsoft/main/org/siemens.com/groups/eyJfdHlwZSI6Ikdyb3VwIiwiaWQiOiI1ODIzNzc5NjM1MiJ9',
             },
             {
               label: 'Siemens Xcelerator Developer Portal',


### PR DESCRIPTION
## 💡 What is the current behavior?

Link in footer links to an outdated community

GitHub Issue Number: #289 

## 🆕 What is the new behavior?

- Link in footer to Viva Engage Community
- News pill in header hidden to have higher attention once V6 is out


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Replaced the footer’s “iX Community” link with a “Viva Engage Community” link.
  * Removed the Release 5.0.0 news item from the navigation bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->