### PR TITLE
refactor: shorten link to sibling document

### DIFF
--- a/docs/guidelines/language/writing-style-guide-getting-started.md
+++ b/docs/guidelines/language/writing-style-guide-getting-started.md
@@ -41,7 +41,7 @@ Learn when and how to write all types of messages including warnings, errors, in
 
 ## Frequent app functions
 
-Get tips for naming common app functions clearly and effectively. This subchapter focuses on how to describe frequent actions and features in a way that users can quickly understand and use. [Read more](../language/frequent-app-functions.md)
+Get tips for naming common app functions clearly and effectively. This subchapter focuses on how to describe frequent actions and features in a way that users can quickly understand and use. [Read more](./frequent-app-functions.md)
 
 
 ## Dialogs and buttons


### PR DESCRIPTION
No need to go up to language as target is in same folder. This breaks when copying the ux writing guide into different folder.

<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #<ISSUE NUMBER>

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->


## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
